### PR TITLE
feat: Add generate_video_handler with AWS Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ build
 .serverless
 node_modules
 venv
+.npmignore

--- a/media-processor/generate_video_handler.py
+++ b/media-processor/generate_video_handler.py
@@ -1,6 +1,7 @@
 import cv2, os
 import numpy as np
 import requests
+import base64
 
 
 def handle(event, context):

--- a/media-processor/generate_video_handler.py
+++ b/media-processor/generate_video_handler.py
@@ -1,0 +1,47 @@
+try:
+    import unzip_requirements
+except ImportError:
+    pass
+
+import cv2, os
+import numpy as np
+import requests
+
+
+def handle(event, context):
+    img_array = []
+    tmp_s3_url = "https://tmp-upload-1111.s3.ap-northeast-2.amazonaws.com"
+    input_images_key = sample_images_list()
+    print(input_images_key)
+
+    for image_key in input_images_key:
+        r = requests.get("/".join((tmp_s3_url, image_key)))
+        print(r.status_code)
+        encoded_img = np.fromstring(r.content, dtype=np.uint8)
+        img = cv2.imdecode(encoded_img, cv2.IMREAD_COLOR)
+        height, width, layers=img.shape
+        size=(width, height)
+        img_array.append(img)
+
+    # os.chdir('/tmp')
+    # 'video-demo.mp4'라는 filename 생성(/tmp에 mp4 생성), 0.5frame/sec
+    output=cv2.VideoWriter('/tmp/video-demo.mp4', cv2.VideoWriter_fourcc(*'mp4v'), 0.5, size)
+    os.system('ls /tmp')
+    for i in range(len(img_array)):
+        output.write(img_array[i])
+    output.release()
+
+    # 만든 mp4 파일 자체를 rb로 열어서 payload로 보내준다.
+    mp4_file = open('/tmp/video-demo.mp4', 'rb')
+    r = requests.put("/".join((tmp_s3_url, "video-demo.mp4")), data=mp4_file)
+    print(r.status_code)
+
+    response = {"statusCode": 200, "body": {"result": "generate video successfully"}}
+
+    return response
+
+
+def sample_images_list():
+    tmp_image_keys = ["sample_images_09.jpg", "sample_images_10.jpg", "sample_images_11.jpg", "sample_images_12.jpg"]
+
+    return tmp_image_keys

--- a/media-processor/generate_video_handler.py
+++ b/media-processor/generate_video_handler.py
@@ -1,8 +1,3 @@
-try:
-    import unzip_requirements
-except ImportError:
-    pass
-
 import cv2, os
 import numpy as np
 import requests
@@ -33,10 +28,17 @@ def handle(event, context):
 
     # 만든 mp4 파일 자체를 rb로 열어서 payload로 보내준다.
     mp4_file = open('/tmp/video-demo.mp4', 'rb')
-    r = requests.put("/".join((tmp_s3_url, "video-demo.mp4")), data=mp4_file)
-    print(r.status_code)
 
-    response = {"statusCode": 200, "body": {"result": "generate video successfully"}}
+    # S3에 업로드하지 않고 /tmp의 내용을 바로 base64를 통해 encode, decode하고
+    # Content-Type을 정의함으로써 binary data를 전달할 수 있음.
+    response = {
+        "headers": {
+            "Content-Type": "video/mp4",
+        },
+        'isBase64Encoded': True,
+        "statusCode": 200,
+        "body": base64.b64encode(mp4_file.read()).decode('utf-8'),
+    }
 
     return response
 

--- a/media-processor/serverless.yml
+++ b/media-processor/serverless.yml
@@ -29,6 +29,13 @@ functions:
       - httpApi:
           path: /panorama
           method: get
+  video:
+    handler: generate_video_handler.handle
+    events:
+      - httpApi:
+          path: /video
+          method: get
+
 plugins:
   # 로컬에서 http로 핸들러를 트리거하기 위함
   - serverless-offline


### PR DESCRIPTION
What I did.
- generate mp4 from images using opencv
- upload mp4 to AWS s3

`output=cv2.VideoWriter('/tmp/video-demo.mp4', cv2.VideoWriter_fourcc(*'mp4v'), 0.5, size)`를 하여 `/tmp` 안에 video file을 만들었습니다. `/tmp` 는 temporoal storage로 임시로 data를 저장한다고 합니다. `/tmp` 외에는 생성이 안 되는 듯 해요. 
그리고 정상적으로 `tmp-upload-1111` bucket에 upload 되는 것 까지 확인하였습니다.
지금은 mp4 파일을 직접 s3로 업로드 했지만 추후에는 바이트 데이터를 payload로 보내는 방법 등으로 개선해야 할 듯 합니다.

ref) [AWS Lambda Storage 관련 링크](https://aws.amazon.com/ko/blogs/compute/choosing-between-aws-lambda-data-storage-options-in-web-apps/)
