### PR TITLE
Query string으로 사진 리스트 조회하도록 변경

### DIFF
--- a/rest-api/dto/picture.go
+++ b/rest-api/dto/picture.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudfront/sign"
 	"github.com/depromeet/everybody-backend/rest-api/config"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/depromeet/everybody-backend/rest-api/ent"
+	log "github.com/sirupsen/logrus"
 )
 
 type PictureRequest struct {
@@ -18,6 +17,13 @@ type PictureRequest struct {
 	BodyPart string `json:"body_part"`
 	// Gateway에서 image key 값도 같이 받음
 	Key string `json:"key"`
+}
+
+// 사진 조회할 때 query string으로 오는 것 처리
+type PictureQueryString struct {
+	Uploader string `query:"uploader"`
+	Album    string `query:"album"`
+	BodyPart string `query:"body_part"`
 }
 
 // type PictureMultiPart struct {

--- a/rest-api/dto/picture.go
+++ b/rest-api/dto/picture.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type PictureRequest struct {
+type CreatePictureRequest struct {
 	ID       int    `json:"id"`
 	AlbumID  int    `json:"album_id"`
 	BodyPart string `json:"body_part"`
@@ -20,7 +20,7 @@ type PictureRequest struct {
 }
 
 // 사진 조회할 때 query string으로 오는 것 처리
-type PictureQueryString struct {
+type GetPictureRequest struct {
 	Uploader string `query:"uploader"`
 	Album    string `query:"album"`
 	BodyPart string `query:"body_part"`

--- a/rest-api/infra/http/handler/pictureHandler.go
+++ b/rest-api/infra/http/handler/pictureHandler.go
@@ -26,7 +26,7 @@ func (h *PictureHandler) SavePicture(ctx *fiber.Ctx) error {
 		return errors.WithStack(err)
 	}
 
-	pictureReq := new(dto.PictureRequest)
+	pictureReq := new(dto.CreatePictureRequest)
 	err = ctx.BodyParser(pictureReq)
 	if err != nil {
 		return errors.WithStack(err)
@@ -66,18 +66,18 @@ func (h *PictureHandler) GetAllPictures(ctx *fiber.Ctx) error {
 		return errors.WithStack(err)
 	}
 
-	pictureQueryString := new(dto.PictureQueryString)
-	err = ctx.QueryParser(pictureQueryString)
+	pictureReq := new(dto.GetPictureRequest)
+	err = ctx.QueryParser(pictureReq)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	// query string으로 uploader가 없다면 잘못된 요청
-	if len(pictureQueryString.Uploader) == 0 {
+	// query string으로 uploader, album이 둘 다 없다면 잘못된 요청
+	if len(pictureReq.Uploader) == 0 && len(pictureReq.Album) == 0 {
 		return errors.WithStack(errors.New("적절한 query string으로 요청해주세요"))
 	}
 
-	pictures, err := h.pictureService.GetAllPictures(userID, pictureQueryString)
+	pictures, err := h.pictureService.GetAllPictures(userID, pictureReq)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/rest-api/infra/http/server.go
+++ b/rest-api/infra/http/server.go
@@ -61,9 +61,8 @@ func addAlbumHandlers(app *fiber.App, albumHandler *handler.AlbumHandler) {
 func addPictureHandlers(app *fiber.App, pictureHandler *handler.PictureHandler) {
 	group := app.Group("/pictures")
 	group.Post("", pictureHandler.SavePicture)
+	// query string으로 구분(uploader=?&album=?&body_part=?)
 	group.Get("", pictureHandler.GetAllPictures)
-	// /pictures/filter?album_id={album_id}&body_part={body_part}
-	group.Get("/filter", pictureHandler.GetPictures)
 	group.Get("/:picture_id", pictureHandler.GetPicture)
 }
 

--- a/rest-api/mocks/picture_service_interface.go
+++ b/rest-api/mocks/picture_service_interface.go
@@ -12,13 +12,13 @@ type PictureServiceInterface struct {
 	mock.Mock
 }
 
-// GetAllPictures provides a mock function with given fields: userID
-func (_m *PictureServiceInterface) GetAllPictures(userID int) (dto.PicturesDto, error) {
-	ret := _m.Called(userID)
+// GetAllPictures provides a mock function with given fields: userID, pictureReq
+func (_m *PictureServiceInterface) GetAllPictures(userID int, pictureReq *dto.GetPictureRequest) (dto.PicturesDto, error) {
+	ret := _m.Called(userID, pictureReq)
 
 	var r0 dto.PicturesDto
-	if rf, ok := ret.Get(0).(func(int) dto.PicturesDto); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(int, *dto.GetPictureRequest) dto.PicturesDto); ok {
+		r0 = rf(userID, pictureReq)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(dto.PicturesDto)
@@ -26,8 +26,8 @@ func (_m *PictureServiceInterface) GetAllPictures(userID int) (dto.PicturesDto, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(userID)
+	if rf, ok := ret.Get(1).(func(int, *dto.GetPictureRequest) error); ok {
+		r1 = rf(userID, pictureReq)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -58,35 +58,12 @@ func (_m *PictureServiceInterface) GetPicture(pictureID int) (*dto.PictureDto, e
 	return r0, r1
 }
 
-// GetPictures provides a mock function with given fields: albumID, bodyPart
-func (_m *PictureServiceInterface) GetPictures(albumID int, bodyPart string) (dto.PicturesDto, error) {
-	ret := _m.Called(albumID, bodyPart)
-
-	var r0 dto.PicturesDto
-	if rf, ok := ret.Get(0).(func(int, string) dto.PicturesDto); ok {
-		r0 = rf(albumID, bodyPart)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(dto.PicturesDto)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int, string) error); ok {
-		r1 = rf(albumID, bodyPart)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // SavePicture provides a mock function with given fields: userID, pictureReq
-func (_m *PictureServiceInterface) SavePicture(userID int, pictureReq *dto.PictureRequest) (*dto.PictureDto, error) {
+func (_m *PictureServiceInterface) SavePicture(userID int, pictureReq *dto.CreatePictureRequest) (*dto.PictureDto, error) {
 	ret := _m.Called(userID, pictureReq)
 
 	var r0 *dto.PictureDto
-	if rf, ok := ret.Get(0).(func(int, *dto.PictureRequest) *dto.PictureDto); ok {
+	if rf, ok := ret.Get(0).(func(int, *dto.CreatePictureRequest) *dto.PictureDto); ok {
 		r0 = rf(userID, pictureReq)
 	} else {
 		if ret.Get(0) != nil {
@@ -95,7 +72,7 @@ func (_m *PictureServiceInterface) SavePicture(userID int, pictureReq *dto.Pictu
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(int, *dto.PictureRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(int, *dto.CreatePictureRequest) error); ok {
 		r1 = rf(userID, pictureReq)
 	} else {
 		r1 = ret.Error(1)

--- a/rest-api/service/picture_test.go
+++ b/rest-api/service/picture_test.go
@@ -26,7 +26,7 @@ func TestPictureServiceSave(t *testing.T) {
 		}
 
 		pictureRepo.On("Save", mock.AnythingOfType("*ent.Picture")).Return(expectedPicture, nil)
-		picture, err := pictureSvc.SavePicture(1, &dto.PictureRequest{})
+		picture, err := pictureSvc.SavePicture(1, &dto.CreatePictureRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PictureToDto(expectedPicture), picture)
 	})
@@ -39,28 +39,28 @@ func TestPictureServiceGetAll(t *testing.T) {
 
 	t.Run("유저 전체 사진 조회 성공", func(t *testing.T) {
 		pictureRepo.On("GetAllByUserID", mock.AnythingOfType("int")).Return(expectedPictures, nil)
-		pictureQueryString := new(dto.PictureQueryString)
-		pictureQueryString.Uploader = "1"
-		pictures, err := pictureSvc.GetAllPictures(1, pictureQueryString)
+		pictureReq := new(dto.GetPictureRequest)
+		pictureReq.Uploader = "1"
+		pictures, err := pictureSvc.GetAllPictures(1, pictureReq)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
 
 	t.Run("특정 앨범 내의 사진들 조회 성공", func(t *testing.T) {
 		pictureRepo.On("GetAllByAlbumID", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
-		pictureQueryString := new(dto.PictureQueryString)
-		pictureQueryString.Album = "1"
-		pictures, err := pictureSvc.GetAllPictures(1, pictureQueryString)
+		pictureReq := new(dto.GetPictureRequest)
+		pictureReq.Album = "1"
+		pictures, err := pictureSvc.GetAllPictures(1, pictureReq)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
 
 	t.Run("특정 앨범 및 신체 부위의 사진들 조회 성공", func(t *testing.T) {
 		pictureRepo.On("FindByAlbumIDAndBodyPart", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
-		pictureQueryString := new(dto.PictureQueryString)
-		pictureQueryString.Album = "1"
-		pictureQueryString.BodyPart = "body"
-		pictures, err := pictureSvc.GetAllPictures(1, pictureQueryString)
+		pictureReq := new(dto.GetPictureRequest)
+		pictureReq.Album = "1"
+		pictureReq.BodyPart = "body"
+		pictures, err := pictureSvc.GetAllPictures(1, pictureReq)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})

--- a/rest-api/service/picture_test.go
+++ b/rest-api/service/picture_test.go
@@ -32,18 +32,39 @@ func TestPictureServiceSave(t *testing.T) {
 	})
 }
 
-func TestPictureServiceGetAllByUserID(t *testing.T) {
-	t.Run("유저의 전체 사진들 조회 성공", func(t *testing.T) {
-		pictureSvc := initializePictureTest(t)
-		var expectedPictures []*ent.Picture
+// 사진 전체 조회 테스트 코드
+func TestPictureServiceGetAll(t *testing.T) {
+	pictureSvc := initializePictureTest(t)
+	var expectedPictures []*ent.Picture
 
+	t.Run("유저 전체 사진 조회 성공", func(t *testing.T) {
 		pictureRepo.On("GetAllByUserID", mock.AnythingOfType("int")).Return(expectedPictures, nil)
-		pictures, err := pictureSvc.GetAllPictures(1)
+		pictureQueryString := new(dto.PictureQueryString)
+		pictureQueryString.Uploader = "1"
+		pictures, err := pictureSvc.GetAllPictures(1, pictureQueryString)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
 
-	// TODO: error test
+	t.Run("특정 앨범 내의 사진들 조회 성공", func(t *testing.T) {
+		pictureRepo.On("GetAllByAlbumID", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
+		pictureQueryString := new(dto.PictureQueryString)
+		pictureQueryString.Album = "1"
+		pictures, err := pictureSvc.GetAllPictures(1, pictureQueryString)
+		assert.NoError(t, err)
+		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
+	})
+
+	t.Run("특정 앨범 및 신체 부위의 사진들 조회 성공", func(t *testing.T) {
+		pictureRepo.On("FindByAlbumIDAndBodyPart", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
+		pictureQueryString := new(dto.PictureQueryString)
+		pictureQueryString.Album = "1"
+		pictureQueryString.BodyPart = "body"
+		pictures, err := pictureSvc.GetAllPictures(1, pictureQueryString)
+		assert.NoError(t, err)
+		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
+	})
+
 }
 
 func TestPictureServiceGet(t *testing.T) {
@@ -62,27 +83,6 @@ func TestPictureServiceGet(t *testing.T) {
 		picture, err := pictureSvc.GetPicture(1)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PictureToDto(expectedPicture), picture)
-	})
-
-	// TODO: error test
-}
-
-func TestPictureServiceGets(t *testing.T) {
-	pictureSvc := initializePictureTest(t)
-	var expectedPictures []*ent.Picture
-
-	t.Run("특정 앨범 및 신체 부위의 사진들 조회 성공", func(t *testing.T) {
-		pictureRepo.On("FindByAlbumIDAndBodyPart", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
-		pictures, err := pictureSvc.GetPictures(1, "body")
-		assert.NoError(t, err)
-		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
-	})
-
-	t.Run("특정 앨범 사진들 조회 성공", func(t *testing.T) {
-		pictureRepo.On("GetAllByAlbumID", mock.AnythingOfType("int")).Return(expectedPictures, nil)
-		pictures, err := pictureSvc.GetPictures(1, "")
-		assert.NoError(t, err)
-		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
 
 	// TODO: error test


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
사진 리스트를 query string에 맞게 조회하도록 변경
#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- GET `/pictures` endpoint에서 각 query string에 해당하는 사진들을 조회하도록 변경
  - `/pictures?uploader={user}` - uploader의 값인 유저 id에 해당하는 업로드의 사진 전체를 조회
  - `/pictures?album={album_id}` - 앨범 id에 해당하는 사진들을 조회
  - `/pictures?album={album_id}&body_part={body_part}` - 앨범 id 및 신체 부위에 해당하는 사진들을 조회
- 현재는 uploader의 유저 id와 사진을 조회 요청하는 유저 id가 사실상 같고 추후에 타인의 사진들을 볼 수 있는? 그런 형태로 확장이 된다면 uploader가 아니어도 조회할 수 있는 그런 구조가 될 것 같습니다.
- Picture Dto에서 기존의 `PictureRequest` 와 `PictureQueryString` 을 각 용도에 맞도록 `CreatePictureRequest`, `GetPictureRequest` 로 바꾸어서 역할을 명확히 함
#### 📸 ScreenShot
<!-- Optional -->

##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked PR Comment
https://github.com/depromeet/everybody-backend/pull/22#discussion_r738741708
