### PR TITLE
앨범 및 사진의 리소스 접근 권한 로직 추가

### DIFF
--- a/rest-api/infra/http/handler/albumHandler.go
+++ b/rest-api/infra/http/handler/albumHandler.go
@@ -1,13 +1,13 @@
 package handler
 
 import (
-	"github.com/pkg/errors"
 	"strconv"
 
 	"github.com/depromeet/everybody-backend/rest-api/dto"
 	"github.com/depromeet/everybody-backend/rest-api/service"
 	"github.com/depromeet/everybody-backend/rest-api/util"
 	"github.com/gofiber/fiber/v2"
+	"github.com/pkg/errors"
 )
 
 type AlbumHandler struct {
@@ -57,6 +57,11 @@ func (h *AlbumHandler) GetAllAlbums(ctx *fiber.Ctx) error {
 
 // GetAlbum은 각 album의 정보와 사진들을 조회
 func (h *AlbumHandler) GetAlbum(ctx *fiber.Ctx) error {
+	userID, err := util.GetRequestUserID(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	param := util.GetParams(ctx, "album_id")
 	if param == "" {
 		return errors.New("params should be provided")
@@ -68,7 +73,7 @@ func (h *AlbumHandler) GetAlbum(ctx *fiber.Ctx) error {
 	}
 
 	// GetAlbum 에서 각 앨범에 해당하는 pictures도 조회해야 함
-	albumData, err := h.albumService.GetAlbum(albumID)
+	albumData, err := h.albumService.GetAlbum(userID, albumID)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/rest-api/infra/http/handler/pictureHandler.go
+++ b/rest-api/infra/http/handler/pictureHandler.go
@@ -12,6 +12,7 @@ import (
 
 type PictureHandler struct {
 	pictureService service.PictureServiceInterface
+	albumService   service.AlbumServiceInterface
 }
 
 func NewPictureHandler(pictureService service.PictureServiceInterface) *PictureHandler {
@@ -41,6 +42,10 @@ func (h *PictureHandler) SavePicture(ctx *fiber.Ctx) error {
 }
 
 func (h *PictureHandler) GetPicture(ctx *fiber.Ctx) error {
+	userID, err := util.GetRequestUserID(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	param := util.GetParams(ctx, "picture_id")
 	if len(param) == 0 {
 		return errors.WithStack(errors.New("picture_id params를 입력해주세요"))
@@ -51,7 +56,7 @@ func (h *PictureHandler) GetPicture(ctx *fiber.Ctx) error {
 		return errors.WithStack(err)
 	}
 
-	picture, err := h.pictureService.GetPicture(pictureID)
+	picture, err := h.pictureService.GetPicture(userID, pictureID)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/depromeet/everybody-backend/rest-api/adapter/push"
 	"github.com/depromeet/everybody-backend/rest-api/config"
 	_ "github.com/depromeet/everybody-backend/rest-api/config"
@@ -12,7 +14,6 @@ import (
 	"github.com/depromeet/everybody-backend/rest-api/service"
 	"github.com/gofiber/fiber/v2"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 var (
@@ -67,7 +68,7 @@ func initialize() {
 	deviceService = service.NewDeviceService(deviceRepo)
 	userService = service.NewUserService(userRepo, notificationService, deviceService)
 	albumService = service.NewAlbumService(albumRepo, pictureRepo)
-	pictureService = service.NewPictureService(pictureRepo)
+	pictureService = service.NewPictureService(pictureRepo, albumRepo)
 	videoService = service.NewVideoService(videoRepo)
 
 	userHandler = handler.NewUserHandler(userService)

--- a/rest-api/mocks/album_service_interface.go
+++ b/rest-api/mocks/album_service_interface.go
@@ -35,13 +35,13 @@ func (_m *AlbumServiceInterface) CreateAlbum(userID int, albumReq *dto.AlbumRequ
 	return r0, r1
 }
 
-// GetAlbum provides a mock function with given fields: albumID
-func (_m *AlbumServiceInterface) GetAlbum(albumID int) (*dto.AlbumDto, error) {
-	ret := _m.Called(albumID)
+// GetAlbum provides a mock function with given fields: userID, albumID
+func (_m *AlbumServiceInterface) GetAlbum(userID int, albumID int) (*dto.AlbumDto, error) {
+	ret := _m.Called(userID, albumID)
 
 	var r0 *dto.AlbumDto
-	if rf, ok := ret.Get(0).(func(int) *dto.AlbumDto); ok {
-		r0 = rf(albumID)
+	if rf, ok := ret.Get(0).(func(int, int) *dto.AlbumDto); ok {
+		r0 = rf(userID, albumID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*dto.AlbumDto)
@@ -49,8 +49,8 @@ func (_m *AlbumServiceInterface) GetAlbum(albumID int) (*dto.AlbumDto, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(albumID)
+	if rf, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = rf(userID, albumID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/rest-api/mocks/picture_service_interface.go
+++ b/rest-api/mocks/picture_service_interface.go
@@ -35,13 +35,13 @@ func (_m *PictureServiceInterface) GetAllPictures(userID int, pictureReq *dto.Ge
 	return r0, r1
 }
 
-// GetPicture provides a mock function with given fields: pictureID
-func (_m *PictureServiceInterface) GetPicture(pictureID int) (*dto.PictureDto, error) {
-	ret := _m.Called(pictureID)
+// GetPicture provides a mock function with given fields: userID, pictureID
+func (_m *PictureServiceInterface) GetPicture(userID int, pictureID int) (*dto.PictureDto, error) {
+	ret := _m.Called(userID, pictureID)
 
 	var r0 *dto.PictureDto
-	if rf, ok := ret.Get(0).(func(int) *dto.PictureDto); ok {
-		r0 = rf(pictureID)
+	if rf, ok := ret.Get(0).(func(int, int) *dto.PictureDto); ok {
+		r0 = rf(userID, pictureID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*dto.PictureDto)
@@ -49,8 +49,8 @@ func (_m *PictureServiceInterface) GetPicture(pictureID int) (*dto.PictureDto, e
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(pictureID)
+	if rf, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = rf(userID, pictureID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/rest-api/repository/album.go
+++ b/rest-api/repository/album.go
@@ -2,11 +2,11 @@ package repository
 
 import (
 	"context"
-	"github.com/pkg/errors"
 
 	"github.com/depromeet/everybody-backend/rest-api/ent"
 	"github.com/depromeet/everybody-backend/rest-api/ent/album"
 	"github.com/depromeet/everybody-backend/rest-api/ent/user"
+	"github.com/pkg/errors"
 )
 
 type albumRepository struct {
@@ -41,6 +41,7 @@ func (r *albumRepository) Create(album *ent.Album) (*ent.Album, error) {
 func (r *albumRepository) GetAllByUserID(userID int) ([]*ent.Album, error) {
 	albums, err := r.db.Album.Query().
 		Where(album.HasUserWith(user.ID(userID))).
+		WithUser().
 		All(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -52,6 +53,7 @@ func (r *albumRepository) GetAllByUserID(userID int) ([]*ent.Album, error) {
 func (r *albumRepository) Get(albumID int) (*ent.Album, error) {
 	albumData, err := r.db.Album.Query().
 		Where(album.ID(albumID)).
+		WithUser().
 		Only(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/rest-api/repository/picture.go
+++ b/rest-api/repository/picture.go
@@ -2,12 +2,12 @@ package repository
 
 import (
 	"context"
-	"github.com/pkg/errors"
 
 	"github.com/depromeet/everybody-backend/rest-api/ent"
 	"github.com/depromeet/everybody-backend/rest-api/ent/album"
 	"github.com/depromeet/everybody-backend/rest-api/ent/picture"
 	"github.com/depromeet/everybody-backend/rest-api/ent/user"
+	"github.com/pkg/errors"
 )
 
 type pictureRepository struct {

--- a/rest-api/service/album_test.go
+++ b/rest-api/service/album_test.go
@@ -34,6 +34,10 @@ func TestAlbumServiceGetAllByUserID(t *testing.T) {
 		albumSvc := initializeAlbumService(t)
 		var expectedAlbums []*ent.Album
 		var expectedPictures []*ent.Picture
+		expectedAlbums = append(expectedAlbums, &ent.Album{
+			ID:   0,
+			Name: "0th",
+		})
 
 		albumRepo.On("GetAllByUserID", mock.AnythingOfType("int")).Return(expectedAlbums, nil)
 		pictureRepo.On("GetAllByUserID", mock.AnythingOfType("int")).Return(expectedPictures, nil)
@@ -49,7 +53,7 @@ func TestAlbumServiceGetAllByUserID(t *testing.T) {
 			expectedAlbumsWithPictures = append(expectedAlbumsWithPictures, album)
 		}
 
-		albums, err := albumSvc.GetAllAlbums(1)
+		albums, err := albumSvc.GetAllAlbums(0)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.AlbumsToDto(expectedAlbumsWithPictures), albums)
 	})
@@ -60,12 +64,16 @@ func TestAlbumServiceGetAllByUserID(t *testing.T) {
 func TestAlbumServiceGet(t *testing.T) {
 	t.Run("각 앨범 조회 성공", func(t *testing.T) {
 		albumSvc := initializeAlbumService(t)
-		expectedAlbum := new(ent.Album)
+		expectedAlbum := &ent.Album{
+			Edges: ent.AlbumEdges{
+				User: &ent.User{ID: 0},
+			},
+		}
 		var expectedPictures []*ent.Picture
 
 		albumRepo.On("Get", mock.AnythingOfType("int")).Return(expectedAlbum, nil)
 		pictureRepo.On("GetAllByAlbumID", mock.AnythingOfType("int")).Return(expectedPictures, nil)
-		album, err := albumSvc.GetAlbum(1)
+		album, err := albumSvc.GetAlbum(0, 1)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.AlbumToDto(expectedAlbum, expectedPictures), album)
 	})

--- a/rest-api/service/picture_test.go
+++ b/rest-api/service/picture_test.go
@@ -12,21 +12,27 @@ import (
 func initializePictureTest(t *testing.T) *pictureService {
 	initialize(t)
 
-	return NewPictureService(pictureRepo).(*pictureService)
+	return NewPictureService(pictureRepo, albumRepo).(*pictureService)
 }
 
 func TestPictureServiceSave(t *testing.T) {
 	t.Run("사진 업로드, 저장 성공", func(t *testing.T) {
 		pictureSvc := initializePictureTest(t)
+		expectedAlbum := &ent.Album{
+			Edges: ent.AlbumEdges{
+				User: &ent.User{ID: 0},
+			},
+		}
 		expectedPicture := &ent.Picture{
 			Edges: ent.PictureEdges{
-				User:  &ent.User{},
-				Album: &ent.Album{},
+				User:  &ent.User{ID: 0},
+				Album: &ent.Album{ID: 0},
 			},
 		}
 
+		albumRepo.On("Get", mock.AnythingOfType("int")).Return(expectedAlbum, nil)
 		pictureRepo.On("Save", mock.AnythingOfType("*ent.Picture")).Return(expectedPicture, nil)
-		picture, err := pictureSvc.SavePicture(1, &dto.CreatePictureRequest{})
+		picture, err := pictureSvc.SavePicture(0, &dto.CreatePictureRequest{AlbumID: 0})
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PictureToDto(expectedPicture), picture)
 	})
@@ -36,12 +42,18 @@ func TestPictureServiceSave(t *testing.T) {
 func TestPictureServiceGetAll(t *testing.T) {
 	pictureSvc := initializePictureTest(t)
 	var expectedPictures []*ent.Picture
+	expectedPictures = append(expectedPictures, &ent.Picture{
+		BodyPart: "upper",
+		Edges: ent.PictureEdges{
+			User:  &ent.User{ID: 0},
+			Album: &ent.Album{ID: 0},
+		}})
 
 	t.Run("유저 전체 사진 조회 성공", func(t *testing.T) {
 		pictureRepo.On("GetAllByUserID", mock.AnythingOfType("int")).Return(expectedPictures, nil)
 		pictureReq := new(dto.GetPictureRequest)
-		pictureReq.Uploader = "1"
-		pictures, err := pictureSvc.GetAllPictures(1, pictureReq)
+		pictureReq.Uploader = "0"
+		pictures, err := pictureSvc.GetAllPictures(0, pictureReq)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
@@ -49,8 +61,8 @@ func TestPictureServiceGetAll(t *testing.T) {
 	t.Run("특정 앨범 내의 사진들 조회 성공", func(t *testing.T) {
 		pictureRepo.On("GetAllByAlbumID", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
 		pictureReq := new(dto.GetPictureRequest)
-		pictureReq.Album = "1"
-		pictures, err := pictureSvc.GetAllPictures(1, pictureReq)
+		pictureReq.Album = "0"
+		pictures, err := pictureSvc.GetAllPictures(0, pictureReq)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
@@ -58,9 +70,9 @@ func TestPictureServiceGetAll(t *testing.T) {
 	t.Run("특정 앨범 및 신체 부위의 사진들 조회 성공", func(t *testing.T) {
 		pictureRepo.On("FindByAlbumIDAndBodyPart", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(expectedPictures, nil)
 		pictureReq := new(dto.GetPictureRequest)
-		pictureReq.Album = "1"
-		pictureReq.BodyPart = "body"
-		pictures, err := pictureSvc.GetAllPictures(1, pictureReq)
+		pictureReq.Album = "0"
+		pictureReq.BodyPart = "upper"
+		pictures, err := pictureSvc.GetAllPictures(0, pictureReq)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PicturesToDto(expectedPictures), pictures)
 	})
@@ -80,7 +92,7 @@ func TestPictureServiceGet(t *testing.T) {
 		}
 
 		pictureRepo.On("Get", mock.AnythingOfType("int")).Return(expectedPicture, nil)
-		picture, err := pictureSvc.GetPicture(1)
+		picture, err := pictureSvc.GetPicture(0, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PictureToDto(expectedPicture), picture)
 	})


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
- 기존의 앨범과 사진의 리소스 접근을 요청하는 유저와 앨범, 사진 데이터의 소유자가 다르더라도 요청을 허용하였던 것을 요청하는 유저와 각 리소스의 소유자가 같아야지만 허용하도록 하는 로직을 추가하였습니다.
#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- 사진 service layer에서 사진의 저장, 조회하는 부분에 요청하는 userID와 query한 사진 데이터의 userID를 비교해서 다르다면 에러를 리턴하도록 변경
  - 조회하는 것 뿐만 아니라 사진을 저장할 때도 적용
    - Request Body의 앨범 id로 앨범이 존재하는지 먼저 찾고 없으면 에러를 리턴
    - 앨범이 존재한다면 그 앨범의 유저 id와 요청하는 유저 id를 비교해서 다르다면 리소스에 접근 금지하도록
- 앨범 service layer에서는 앨범 하나를 조회할 때 요청하는 유저 id와 query한 앨범의 유저 id를 비교해서 다르다면 리소스에 접근 금지
- 사진과 앨범 service layer에서 리스트를 조회할 때 데이터가 없다면 [](빈 리스트)를 응답으로 줬던 것을 리소스를 찾지 못했다는 에러를 응답으로 주는 것으로 변경
- 리소스 권한 혹은 리소스가 없는 경우에 대한 에러 처리에 대한 보완이 필요합니다.(지금은 그냥 `errors.WithStack(errors.New("접근 권한 없습니다"))` 이런 식으로 임시로 처리했어요ㅠ)
- 테스트 코드도 위의 변화에 맞게 수정함

#### 보완 및 협의해야 할 점
- 에러 처리(wrapping) 하는 부분을 이번 주 토요일에 만나면 같이 협의 나누면 좋겠어요. 리소스 접근 권한이 없는 경우(forbidden), 리소스가 없는 경우(notfound), 잘못된 요청(bad request)등과 같은 에러 처리 부분을 정하면 좋을 것 같습니다~
#### 📸 ScreenShot
<!-- Optional -->
![image](https://user-images.githubusercontent.com/44899448/139879433-24433446-e5b9-43ea-86a6-92ff050c3fa9.png)  
- 사진 조회를 요청하는 `user(1)`와 찾고자 하는 사진의 `uploader(2)` 가 다르면 조회하지 못하도록 막음  



![image](https://user-images.githubusercontent.com/44899448/139880885-d4deb589-0238-4205-a599-9af32b2e4974.png)
![image](https://user-images.githubusercontent.com/44899448/139881939-f37d4ca9-bcca-4444-ba88-8c65fc4b0dc7.png)

- 데이터베이스에 저장되어 있는 앨범의 id는 3이고 유저 id는 1인 상황
- 사진 저장하기 위한 Reqeuest body에는 album_id를 3이라고 했고 header의 {{user}}의 값은 2인 상태에서 요청을 보내면 에러를 응답함
##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked issue
close #
