### PR TITLE
feat: 가장 안쪽 스택만 trace

### DIFF
--- a/rest-api/go.mod
+++ b/rest-api/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/pkg/errors v0.9.1 => github.com/depromeet/errors v0.9.2

--- a/rest-api/go.sum
+++ b/rest-api/go.sum
@@ -80,6 +80,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/depromeet/errors v0.9.2 h1:iWLzTFguTeRYTUeDXj3cFvV+jq/GnkNIMRsO/rILtpo=
+github.com/depromeet/errors v0.9.2/go.mod h1:1UUhzLXT3Vvk0yvjGcSxZVbDsd/IFYH9MShusNXNIAY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -258,8 +260,6 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/rest-api/infra/http/handler/albumHandler.go
+++ b/rest-api/infra/http/handler/albumHandler.go
@@ -3,11 +3,11 @@ package handler
 import (
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/depromeet/everybody-backend/rest-api/dto"
 	"github.com/depromeet/everybody-backend/rest-api/service"
 	"github.com/depromeet/everybody-backend/rest-api/util"
 	"github.com/gofiber/fiber/v2"
-	"github.com/pkg/errors"
 )
 
 type AlbumHandler struct {

--- a/rest-api/infra/http/middleware.go
+++ b/rest-api/infra/http/middleware.go
@@ -1,9 +1,9 @@
 package http
 
 import (
-	"errors"
-	"github.com/depromeet/everybody-backend/rest-api/ent"
+	"github.com/depromeet/everybody-backend/rest-api/service"
 	"github.com/gofiber/fiber/v2"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
@@ -17,12 +17,12 @@ type ErrorResponse struct {
 // errorHandle 은 최종적으로 리턴된 error들에 대해 적절한 응답을 생성하고
 // 예상치 못한 에러의 경우 500 에러로 응답합니다.
 func errorHandle(ctx *fiber.Ctx, err error) error {
-	log.Error(err)
-	notFoundErr := &ent.NotFoundError{}
-	if errors.As(err, &notFoundErr) {
+	rootErr := errors.GetRootStackError(err)
+	log.Errorf("%+v", rootErr)
+	n := new(service.NotFoundError)
+	if errors.As(err, n) {
 		return ctx.Status(404).JSON(e("리소스를 찾을 수 없습니다.", reflect.TypeOf(err).Name()))
 	} else {
-		log.Errorf("%+v", err)
 		return ctx.Status(500).JSON(e("알 수 없는 에러가 발생했습니다. 에브리바디에 문의해주세요.", "internalError"))
 	}
 }

--- a/rest-api/infra/routine/notification.go
+++ b/rest-api/infra/routine/notification.go
@@ -6,6 +6,7 @@
 package routine
 
 import (
+	"fmt"
 	"github.com/depromeet/everybody-backend/rest-api/adapter/push"
 	"github.com/depromeet/everybody-backend/rest-api/config"
 	"github.com/depromeet/everybody-backend/rest-api/service"
@@ -38,7 +39,7 @@ func (r *NotifyRoutine) Run() (err error) {
 		// panic 된 것들도 recover 해서 최대한 Run()이 종료되지 않게 함.
 		if r := recover(); r != nil {
 			log.Errorf("%+v:\n%s", r, debug.Stack())
-			err = errors.WithMessagef(ErrNotifyRoutine, "%s", r)
+			err = errors.Wrap(ErrNotifyRoutine, fmt.Sprintf("%s", r))
 		} else {
 			if err != nil {
 				log.Errorf("%+v", err)

--- a/rest-api/service/error.go
+++ b/rest-api/service/error.go
@@ -1,0 +1,7 @@
+package service
+
+type NotFoundError error
+
+//func IsNotFound(err error) bool {
+//	return ent.IsNotFound(err)
+//}

--- a/rest-api/service/error_test.go
+++ b/rest-api/service/error_test.go
@@ -1,26 +1,21 @@
 package service
 
 import (
+	"github.com/depromeet/everybody-backend/rest-api/ent"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func Test_NotFoundError(t *testing.T) {
-	err := err3()
-	//notFoundErr := NotFoundError(err)
-	//t.Logf("%+v", notFoundErr)
-	t.Logf("%+v", err)
-
-}
-
-func err1() error {
-	return errors.New("err1")
-}
-
-func err2() error {
-	return errors.WithStack(err1(), "err2")
-}
-
-func err3() error {
-	return errors.WithStack(err2(), "err3")
+	var entErr *ent.NotFoundError
+	notFoundErrorPtr := new(NotFoundError)
+	notFoundError := NotFoundError(entErr)
+	assert.ErrorAs(t, &ent.NotFoundError{}, notFoundErrorPtr)
+	assert.ErrorAs(t, &ent.NotFoundError{}, &notFoundError)
+	assert.Panics(t, func() {
+		// panic: errors: *target must be interface or implement error
+		// 타겟은 포인터형이어야한다.
+		errors.As(&ent.NotFoundError{}, notFoundError)
+	})
 }

--- a/rest-api/service/error_test.go
+++ b/rest-api/service/error_test.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"github.com/pkg/errors"
+	"testing"
+)
+
+func Test_NotFoundError(t *testing.T) {
+	err := err3()
+	//notFoundErr := NotFoundError(err)
+	//t.Logf("%+v", notFoundErr)
+	t.Logf("%+v", err)
+
+}
+
+func err1() error {
+	return errors.New("err1")
+}
+
+func err2() error {
+	return errors.WithStack(err1(), "err2")
+}
+
+func err3() error {
+	return errors.WithStack(err2(), "err3")
+}

--- a/rest-api/service/picture.go
+++ b/rest-api/service/picture.go
@@ -32,6 +32,9 @@ func NewPictureService(pictureRepo repository.PictureRepositoryInterface, albumR
 func (s *pictureService) SavePicture(userID int, pictureReq *dto.CreatePictureRequest) (*dto.PictureDto, error) {
 	album, err := s.albumRepo.Get(pictureReq.AlbumID)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, errors.WithStack(NotFoundError(err))
+		}
 		// 사진 저장할 앨범 id가 존재하지 않는 등의 에러
 		return nil, errors.WithStack(err)
 	}

--- a/rest-api/service/user.go
+++ b/rest-api/service/user.go
@@ -128,7 +128,7 @@ func (s *userService) generateUniqueNickname() string {
 
 		if err != nil {
 			log.Errorf("랜덤 닉네임 생성 도중 오류가 발생했습니다. Suffix가 숫자가 아닙니다: %s", last.Nickname)
-			panic(errors.WithMessagef(err, "랜덤 닉네임 생성 도중 오류가 발생했습니다. Suffix가 숫자가 아닙니다."))
+			panic(errors.Wrap(err, "랜덤 닉네임 생성 도중 오류가 발생했습니다. Suffix가 숫자가 아닙니다."))
 		}
 	}
 


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
가장 안쪽 스택만 trace할 수 있어짐. 기존에는 에러를 한 번 `.WithStack()`으로 wrapping할 때마다 해당 시점의 Stack 정보를 모두 담아버려서 스택이 중복되어버렸음.

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
* `pkg/errors`를 포크하여 [`depromeet/errors`](https://github.com/depromeet/errors)에서 새로운 errors 패키지를 만들었어요.
  * 제일 안쪽 스택 정보를 가진 에러의 스택만 trace해야 중복되지 않게 스택 트레이스를 할 수 있는데 stack 정보가 private field라서 `pkg/errors` 패키지 밖에서 접근할 수가 없음. 하고싶은 경우 reflection을 써야하는데 많이 까다로움...
  * 그래서 포크 떠서 그 부분만 살짝 바꿨습니다.
    * `rest-api`에서 import할 때에는 똑같이 `https://github.com/pkg/errors`로 import 해서 사용할 수 있습니다. (go.mod에서 replace하도록 해놨음)
      * replace는 `github.com/pkg/errors`의 이름으로 사용하지만 패키지는 https://github.com/depromeet/errors 를 이용할 수 있게 해줌.
      * https://github.com/depromeet/errors 에서도 go.mod 의 패키지명을 `github.com/pkg/errors` 그대로 사용할 수 있어서 fork 뜬 뒤에 추후에 upstream 레포지토리에 변동사항이 있어도 pull만 받으면 될 듯 해요.
* error를 랩핑하는 방법 => `.WithMessage()`는 별로인 것 같아요. 스택 정보가 안담기고 단순 랩핑이라 `fmt.Errorf()` 랑 비슷한 느낌인 것 같아요.
  * `.WithStack(err error)` - err에 스택 정보를 담은 에러로 랩핑해줌.
  * `.Wrap(err error, message string)` - WithMessage를 이용해 err과 메시지를 담은 에러로 랩핑한 뒤 스택 정보를 담은 에러로 랩핑
  * `.WithMessage(err error, message string` - err에 메시지를 담은 에러로 랩핑 (스택 정보 X)

#### 📸 ScreenShot
<!-- Optional -->
![image](https://user-images.githubusercontent.com/33250725/140614472-256764f8-fe6a-481e-9b16-0e313b341c5d.png)
이런 식으로 정확하면서도 중복되지 않게 순서대로 스택 트레이스가 가능합니다.

##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #
