### PR TITLE
Feat: 앨범 조회 시 속한 사진 정보도 제공

### DIFF
--- a/rest-api/config/config.go
+++ b/rest-api/config/config.go
@@ -39,32 +39,33 @@ func init() {
 var Config *config
 
 type config struct {
-	Port int `yaml:"port"`
+	Port int
 	DB   struct {
 		MySQL struct {
-			Host         string `yaml:"host"`
-			Port         int    `yaml:"port"`
-			DatabaseName string `yaml:"databaseName"`
-			User         string `yaml:"user"`
-			Password     string `yaml:"password"`
-		} `yaml:"mySql"`
-	} `yaml:"db"`
+			Host         string
+			Port         int
+			DatabaseName string
+			User         string
+			Password     string
+		}
+	}
 
 	AWS struct {
-		Profile string `yaml:"profile"`
-		Region  string `yaml:"region"`
-		Bucket  string `yaml:"bucket"`
-	} `yaml:"aws"`
-	ImageRootUrl     string `yaml:"imageRootUrl"`
-	ImagePublicKeyID string `yaml:"imagePublicKeyID"`
-	ImagePrivateKey  string `yaml:"imagePrivateKey"`
-	Push             struct {
+		Profile string
+		Region  string
+		Bucket  string
+	}
+	PublicDriveRootURL string
+	ImageRootUrl       string
+	ImagePublicKeyID   string
+	ImagePrivateKey    string
+	Push               struct {
 		FCM struct {
-			ServiceAccountFile string `yaml:"ServiceAccountFile"`
-		} `yaml:"fcm"`
-	} `yaml:"push"`
+			ServiceAccountFile string
+		}
+	}
 	NotifyRoutine struct {
-		Enabled  bool `yaml:"enabled"`
-		Interval int  `yaml:"interval"`
-	} `yaml:"notifyRoutine"`
+		Enabled  bool
+		Interval int
+	}
 }

--- a/rest-api/config/sample.yml
+++ b/rest-api/config/sample.yml
@@ -12,6 +12,7 @@ aws:
   region: regionName
 # 환경에 맞춰
 # local.yml 혹은 dev.yml 등을 정의해주세요
+publicDriveRootURL: https://some.cloudfront.net or https://some.s3.com
 imageRootURL: https://some.cloudfront.net
 imagePublicKeyID: ABCDEFGHIJK
 imagePrivateKey: |

--- a/rest-api/dto/album.go
+++ b/rest-api/dto/album.go
@@ -24,10 +24,13 @@ type AlbumRequest struct {
 
 type AlbumsDto []*AlbumDto
 type AlbumDto struct {
-	ID        int         `json:"id"`
-	Name      string      `json:"name"`
-	CreatedAt time.Time   `json:"created_at"`
-	Pictures  PicturesDto `json:"pictures"`
+	ID        int       `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	// 클라이언트측에서는 부위별로 분류된 사진 리스트가 필요함.
+	// TODO: 특정 부위의 사진이 한 장도 없을 때 클라이언트 측에서 맵을 사용하면서 undefined 나 no key(?) 같은 에러를 겪지 않게 하려면
+	// 서버측에서 부위에 대한 Enum을 정의해서 각 부위별로 사진이 하나도 없는 부위는 빈 리스트를 전달해줘야할 것 같아요.
+	Pictures map[string]PicturesDto `json:"pictures"`
 
 	// Videos    VideosDto   `json:"videos"`
 }
@@ -45,12 +48,15 @@ func AlbumsToDto(srcAlbums []*ent.Album) AlbumsDto {
 
 func AlbumToDto(srcAlbum *ent.Album, srcPictures []*ent.Picture) *AlbumDto {
 	picturesDto := PicturesToDto(srcPictures)
-
+	picturesMap := make(map[string]PicturesDto)
+	for _, pictureDto := range picturesDto {
+		picturesMap[pictureDto.BodyPart] = append(picturesMap[pictureDto.BodyPart], pictureDto)
+	}
 	return &AlbumDto{
 		ID:        srcAlbum.ID,
 		Name:      srcAlbum.Name,
 		CreatedAt: srcAlbum.CreatedAt,
-		Pictures:  picturesDto,
+		Pictures:  picturesMap,
 		// Videos:
 	}
 }

--- a/rest-api/dto/picture.go
+++ b/rest-api/dto/picture.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"fmt"
+	"github.com/depromeet/everybody-backend/rest-api/util"
 	"strings"
 	"time"
 
@@ -16,9 +17,10 @@ type CreatePictureRequest struct {
 	AlbumID  int    `json:"album_id"`
 	BodyPart string `json:"body_part"`
 	// Gateway에서 image key 값도 같이 받음
-	Key string `json:"key"`
-	// TakenAt은 사진을 찍은 날짜(업로드 날짜와 다름)
-	TakenAt time.Time `json:"taken_at"`
+	Key          string `json:"key"`
+	TakenAtYear  int    `json:"taken_at_year"`
+	TakenAtMonth int    `json:"taken_at_month"`
+	TakenAtDay   int    `json:"taken_at_day"`
 }
 
 // 사진 조회할 때 query string으로 오는 것 처리
@@ -37,20 +39,23 @@ type GetPictureRequest struct {
 type PicturesDto []*PictureDto
 
 type PictureDto struct {
-	ID           int       `json:"id"`
-	AlbumID      int       `json:"album_id"`
-	BodyPart     string    `json:"body_part"`
-	TakenAt      time.Time `json:"taken_at"`
-	Uploaded_at  time.Time `json:"uploaded_at"`
-	ThumbnailURL string    `json:"thumbnail_url"`
-	PreviewURL   string    `json:"preview_url"`
-	ImageURL     string    `json:"image_url"`
+	ID           int    `json:"id"`
+	AlbumID      int    `json:"album_id"`
+	BodyPart     string `json:"body_part"`
+	ThumbnailURL string `json:"thumbnail_url"`
+	PreviewURL   string `json:"preview_url"`
+	ImageURL     string `json:"image_url"`
 	// image의 object key
-	Key string `json:"key"`
+	Key          string    `json:"key"`
+	TakenAtYear  int       `json:"taken_at_year"`
+	TakenAtMonth int       `json:"taken_at_month"`
+	TakenAtDay   int       `json:"taken_at_day"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 func PictureToDto(src *ent.Picture) *PictureDto {
 	thumbnailURL, err := createImageURL(fmt.Sprintf("%d/image/%d/%s", src.Edges.User.ID, 48, src.Key))
+	// TODO(umi0410)
 	// 일단 이 부분까지 하나 하나 에러처리하긴 번거로울 듯?
 	if err != nil {
 		log.Error(err)
@@ -65,16 +70,19 @@ func PictureToDto(src *ent.Picture) *PictureDto {
 	if err != nil {
 		log.Error(err)
 	}
+	year, month, day := util.ConvertTimeToStr(src.TakenAt)
 	return &PictureDto{
 		ID:           src.ID,
 		AlbumID:      src.Edges.Album.ID,
 		BodyPart:     src.BodyPart,
-		TakenAt:      src.TakenAt,
-		Uploaded_at:  src.UploadedAt,
 		ThumbnailURL: thumbnailURL,
 		PreviewURL:   previewURL,
 		ImageURL:     imageURL,
 		Key:          src.Key,
+		TakenAtYear:  year,
+		TakenAtMonth: month,
+		TakenAtDay:   day,
+		CreatedAt:    src.CreatedAt,
 	}
 }
 

--- a/rest-api/dto/picture.go
+++ b/rest-api/dto/picture.go
@@ -17,6 +17,8 @@ type CreatePictureRequest struct {
 	BodyPart string `json:"body_part"`
 	// Gateway에서 image key 값도 같이 받음
 	Key string `json:"key"`
+	// TakenAt은 사진을 찍은 날짜(업로드 날짜와 다름)
+	TakenAt time.Time `json:"taken_at"`
 }
 
 // 사진 조회할 때 query string으로 오는 것 처리
@@ -38,7 +40,8 @@ type PictureDto struct {
 	ID           int       `json:"id"`
 	AlbumID      int       `json:"album_id"`
 	BodyPart     string    `json:"body_part"`
-	CreatedAt    time.Time `json:"created_at"`
+	TakenAt      time.Time `json:"taken_at"`
+	Uploaded_at  time.Time `json:"uploaded_at"`
 	ThumbnailURL string    `json:"thumbnail_url"`
 	PreviewURL   string    `json:"preview_url"`
 	ImageURL     string    `json:"image_url"`
@@ -66,7 +69,8 @@ func PictureToDto(src *ent.Picture) *PictureDto {
 		ID:           src.ID,
 		AlbumID:      src.Edges.Album.ID,
 		BodyPart:     src.BodyPart,
-		CreatedAt:    src.CreatedAt,
+		TakenAt:      src.TakenAt,
+		Uploaded_at:  src.UploadedAt,
 		ThumbnailURL: thumbnailURL,
 		PreviewURL:   previewURL,
 		ImageURL:     imageURL,

--- a/rest-api/dto/user.go
+++ b/rest-api/dto/user.go
@@ -1,7 +1,10 @@
 package dto
 
 import (
+	"fmt"
+	"github.com/depromeet/everybody-backend/rest-api/config"
 	"github.com/depromeet/everybody-backend/rest-api/ent"
+	"github.com/depromeet/everybody-backend/rest-api/ent/user"
 	"time"
 )
 
@@ -26,23 +29,25 @@ type UpdateUserRequest struct {
 }
 
 type UserDto struct {
-	ID        int       `json:"id"`
-	Nickname  string    `json:"nickname"`
-	Motto     string    `json:"motto"`
-	Height    *int      `json:"height"`
-	Weight    *int      `json:"weight"`
-	Kind      string    `json:"kind"`
-	CreatedAt time.Time `json:"created_at"`
+	ID           int       `json:"id"`
+	Nickname     string    `json:"nickname"`
+	Motto        string    `json:"motto"`
+	Height       *int      `json:"height"`
+	Weight       *int      `json:"weight"`
+	Kind         user.Kind `json:"kind"`
+	ProfileImage string    `json:"profile_image"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 func UserToDto(src *ent.User) *UserDto {
 	return &UserDto{
-		ID:        src.ID,
-		Motto:     src.Motto,
-		Nickname:  src.Nickname,
-		Height:    src.Height,
-		Weight:    src.Weight,
-		Kind:      src.Kind.String(),
-		CreatedAt: src.CreatedAt,
+		ID:           src.ID,
+		Motto:        src.Motto,
+		Nickname:     src.Nickname,
+		Height:       src.Height,
+		Weight:       src.Weight,
+		Kind:         src.Kind,
+		ProfileImage: fmt.Sprintf("%s/%s", config.Config.PublicDriveRootURL, src.ProfileImage),
+		CreatedAt:    src.CreatedAt,
 	}
 }

--- a/rest-api/ent/migrate/schema.go
+++ b/rest-api/ent/migrate/schema.go
@@ -86,7 +86,8 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "body_part", Type: field.TypeString},
 		{Name: "key", Type: field.TypeString},
-		{Name: "created_at", Type: field.TypeTime},
+		{Name: "taken_at", Type: field.TypeTime},
+		{Name: "uploaded_at", Type: field.TypeTime},
 		{Name: "album_picture", Type: field.TypeInt, Nullable: true},
 		{Name: "user_picture", Type: field.TypeInt, Nullable: true},
 	}
@@ -98,13 +99,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "pictures_albums_picture",
-				Columns:    []*schema.Column{PicturesColumns[4]},
+				Columns:    []*schema.Column{PicturesColumns[5]},
 				RefColumns: []*schema.Column{AlbumsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "pictures_users_picture",
-				Columns:    []*schema.Column{PicturesColumns[5]},
+				Columns:    []*schema.Column{PicturesColumns[6]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/rest-api/ent/migrate/schema.go
+++ b/rest-api/ent/migrate/schema.go
@@ -114,6 +114,7 @@ var (
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "profile_image", Type: field.TypeString, Nullable: true},
 		{Name: "nickname", Type: field.TypeString},
 		{Name: "motto", Type: field.TypeString, Default: "눈바디와 함께 꾸준히 운동할테야!"},
 		{Name: "height", Type: field.TypeInt, Nullable: true},

--- a/rest-api/ent/migrate/schema.go
+++ b/rest-api/ent/migrate/schema.go
@@ -87,7 +87,7 @@ var (
 		{Name: "body_part", Type: field.TypeString},
 		{Name: "key", Type: field.TypeString},
 		{Name: "taken_at", Type: field.TypeTime},
-		{Name: "uploaded_at", Type: field.TypeTime},
+		{Name: "created_at", Type: field.TypeTime},
 		{Name: "album_picture", Type: field.TypeInt, Nullable: true},
 		{Name: "user_picture", Type: field.TypeInt, Nullable: true},
 	}

--- a/rest-api/ent/mutation.go
+++ b/rest-api/ent/mutation.go
@@ -2635,6 +2635,7 @@ type UserMutation struct {
 	op                         Op
 	typ                        string
 	id                         *int
+	profile_image              *string
 	nickname                   *string
 	motto                      *string
 	height                     *int
@@ -2747,6 +2748,55 @@ func (m *UserMutation) ID() (id int, exists bool) {
 		return
 	}
 	return *m.id, true
+}
+
+// SetProfileImage sets the "profile_image" field.
+func (m *UserMutation) SetProfileImage(s string) {
+	m.profile_image = &s
+}
+
+// ProfileImage returns the value of the "profile_image" field in the mutation.
+func (m *UserMutation) ProfileImage() (r string, exists bool) {
+	v := m.profile_image
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldProfileImage returns the old "profile_image" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldProfileImage(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldProfileImage is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldProfileImage requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldProfileImage: %w", err)
+	}
+	return oldValue.ProfileImage, nil
+}
+
+// ClearProfileImage clears the value of the "profile_image" field.
+func (m *UserMutation) ClearProfileImage() {
+	m.profile_image = nil
+	m.clearedFields[user.FieldProfileImage] = struct{}{}
+}
+
+// ProfileImageCleared returns if the "profile_image" field was cleared in this mutation.
+func (m *UserMutation) ProfileImageCleared() bool {
+	_, ok := m.clearedFields[user.FieldProfileImage]
+	return ok
+}
+
+// ResetProfileImage resets all changes to the "profile_image" field.
+func (m *UserMutation) ResetProfileImage() {
+	m.profile_image = nil
+	delete(m.clearedFields, user.FieldProfileImage)
 }
 
 // SetNickname sets the "nickname" field.
@@ -3322,7 +3372,10 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
+	if m.profile_image != nil {
+		fields = append(fields, user.FieldProfileImage)
+	}
 	if m.nickname != nil {
 		fields = append(fields, user.FieldNickname)
 	}
@@ -3349,6 +3402,8 @@ func (m *UserMutation) Fields() []string {
 // schema.
 func (m *UserMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case user.FieldProfileImage:
+		return m.ProfileImage()
 	case user.FieldNickname:
 		return m.Nickname()
 	case user.FieldMotto:
@@ -3370,6 +3425,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case user.FieldProfileImage:
+		return m.OldProfileImage(ctx)
 	case user.FieldNickname:
 		return m.OldNickname(ctx)
 	case user.FieldMotto:
@@ -3391,6 +3448,13 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 // type.
 func (m *UserMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case user.FieldProfileImage:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetProfileImage(v)
+		return nil
 	case user.FieldNickname:
 		v, ok := value.(string)
 		if !ok {
@@ -3490,6 +3554,9 @@ func (m *UserMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *UserMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(user.FieldProfileImage) {
+		fields = append(fields, user.FieldProfileImage)
+	}
 	if m.FieldCleared(user.FieldHeight) {
 		fields = append(fields, user.FieldHeight)
 	}
@@ -3510,6 +3577,9 @@ func (m *UserMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *UserMutation) ClearField(name string) error {
 	switch name {
+	case user.FieldProfileImage:
+		m.ClearProfileImage()
+		return nil
 	case user.FieldHeight:
 		m.ClearHeight()
 		return nil
@@ -3524,6 +3594,9 @@ func (m *UserMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *UserMutation) ResetField(name string) error {
 	switch name {
+	case user.FieldProfileImage:
+		m.ResetProfileImage()
+		return nil
 	case user.FieldNickname:
 		m.ResetNickname()
 		return nil

--- a/rest-api/ent/mutation.go
+++ b/rest-api/ent/mutation.go
@@ -2056,7 +2056,7 @@ type PictureMutation struct {
 	body_part     *string
 	key           *string
 	taken_at      *time.Time
-	uploaded_at   *time.Time
+	created_at    *time.Time
 	clearedFields map[string]struct{}
 	album         *int
 	clearedalbum  bool
@@ -2254,6 +2254,42 @@ func (m *PictureMutation) ResetTakenAt() {
 	m.taken_at = nil
 }
 
+// SetCreatedAt sets the "created_at" field.
+func (m *PictureMutation) SetCreatedAt(t time.Time) {
+	m.created_at = &t
+}
+
+// TakenAt returns the value of the "taken_at" field in the mutation.
+func (m *PictureMutation) TakenAt() (r time.Time, exists bool) {
+	v := m.taken_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTakenAt returns the old "taken_at" field's value of the Picture entity.
+// If the Picture object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PictureMutation) OldTakenAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldTakenAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldTakenAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTakenAt: %w", err)
+	}
+	return oldValue.TakenAt, nil
+}
+
+// ResetTakenAt resets all changes to the "taken_at" field.
+func (m *PictureMutation) ResetTakenAt() {
+	m.taken_at = nil
+}
+
 // SetUploadedAt sets the "uploaded_at" field.
 func (m *PictureMutation) SetUploadedAt(t time.Time) {
 	m.uploaded_at = &t
@@ -2397,6 +2433,9 @@ func (m *PictureMutation) Fields() []string {
 	if m.taken_at != nil {
 		fields = append(fields, picture.FieldTakenAt)
 	}
+	if m.created_at != nil {
+		fields = append(fields, picture.FieldCreatedAt)
+	}
 	if m.uploaded_at != nil {
 		fields = append(fields, picture.FieldUploadedAt)
 	}
@@ -2414,8 +2453,8 @@ func (m *PictureMutation) Field(name string) (ent.Value, bool) {
 		return m.Key()
 	case picture.FieldTakenAt:
 		return m.TakenAt()
-	case picture.FieldUploadedAt:
-		return m.UploadedAt()
+	case picture.FieldCreatedAt:
+		return m.CreatedAt()
 	}
 	return nil, false
 }
@@ -2431,8 +2470,8 @@ func (m *PictureMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldKey(ctx)
 	case picture.FieldTakenAt:
 		return m.OldTakenAt(ctx)
-	case picture.FieldUploadedAt:
-		return m.OldUploadedAt(ctx)
+	case picture.FieldCreatedAt:
+		return m.OldCreatedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown Picture field %s", name)
 }
@@ -2457,6 +2496,13 @@ func (m *PictureMutation) SetField(name string, value ent.Value) error {
 		m.SetKey(v)
 		return nil
 	case picture.FieldTakenAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTakenAt(v)
+		return nil
+	case picture.FieldCreatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
@@ -2527,6 +2573,9 @@ func (m *PictureMutation) ResetField(name string) error {
 		return nil
 	case picture.FieldTakenAt:
 		m.ResetTakenAt()
+		return nil
+	case picture.FieldCreatedAt:
+		m.ResetCreatedAt()
 		return nil
 	case picture.FieldUploadedAt:
 		m.ResetUploadedAt()

--- a/rest-api/ent/mutation.go
+++ b/rest-api/ent/mutation.go
@@ -2055,7 +2055,8 @@ type PictureMutation struct {
 	id            *int
 	body_part     *string
 	key           *string
-	created_at    *time.Time
+	taken_at      *time.Time
+	uploaded_at   *time.Time
 	clearedFields map[string]struct{}
 	album         *int
 	clearedalbum  bool
@@ -2217,40 +2218,76 @@ func (m *PictureMutation) ResetKey() {
 	m.key = nil
 }
 
-// SetCreatedAt sets the "created_at" field.
-func (m *PictureMutation) SetCreatedAt(t time.Time) {
-	m.created_at = &t
+// SetTakenAt sets the "taken_at" field.
+func (m *PictureMutation) SetTakenAt(t time.Time) {
+	m.taken_at = &t
 }
 
-// CreatedAt returns the value of the "created_at" field in the mutation.
-func (m *PictureMutation) CreatedAt() (r time.Time, exists bool) {
-	v := m.created_at
+// TakenAt returns the value of the "taken_at" field in the mutation.
+func (m *PictureMutation) TakenAt() (r time.Time, exists bool) {
+	v := m.taken_at
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldCreatedAt returns the old "created_at" field's value of the Picture entity.
+// OldTakenAt returns the old "taken_at" field's value of the Picture entity.
 // If the Picture object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PictureMutation) OldCreatedAt(ctx context.Context) (v time.Time, err error) {
+func (m *PictureMutation) OldTakenAt(ctx context.Context) (v time.Time, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, fmt.Errorf("OldCreatedAt is only allowed on UpdateOne operations")
+		return v, fmt.Errorf("OldTakenAt is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, fmt.Errorf("OldCreatedAt requires an ID field in the mutation")
+		return v, fmt.Errorf("OldTakenAt requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldCreatedAt: %w", err)
+		return v, fmt.Errorf("querying old value for OldTakenAt: %w", err)
 	}
-	return oldValue.CreatedAt, nil
+	return oldValue.TakenAt, nil
 }
 
-// ResetCreatedAt resets all changes to the "created_at" field.
-func (m *PictureMutation) ResetCreatedAt() {
-	m.created_at = nil
+// ResetTakenAt resets all changes to the "taken_at" field.
+func (m *PictureMutation) ResetTakenAt() {
+	m.taken_at = nil
+}
+
+// SetUploadedAt sets the "uploaded_at" field.
+func (m *PictureMutation) SetUploadedAt(t time.Time) {
+	m.uploaded_at = &t
+}
+
+// UploadedAt returns the value of the "uploaded_at" field in the mutation.
+func (m *PictureMutation) UploadedAt() (r time.Time, exists bool) {
+	v := m.uploaded_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUploadedAt returns the old "uploaded_at" field's value of the Picture entity.
+// If the Picture object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PictureMutation) OldUploadedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldUploadedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldUploadedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUploadedAt: %w", err)
+	}
+	return oldValue.UploadedAt, nil
+}
+
+// ResetUploadedAt resets all changes to the "uploaded_at" field.
+func (m *PictureMutation) ResetUploadedAt() {
+	m.uploaded_at = nil
 }
 
 // SetAlbumID sets the "album" edge to the Album entity by id.
@@ -2350,15 +2387,18 @@ func (m *PictureMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PictureMutation) Fields() []string {
-	fields := make([]string, 0, 3)
+	fields := make([]string, 0, 4)
 	if m.body_part != nil {
 		fields = append(fields, picture.FieldBodyPart)
 	}
 	if m.key != nil {
 		fields = append(fields, picture.FieldKey)
 	}
-	if m.created_at != nil {
-		fields = append(fields, picture.FieldCreatedAt)
+	if m.taken_at != nil {
+		fields = append(fields, picture.FieldTakenAt)
+	}
+	if m.uploaded_at != nil {
+		fields = append(fields, picture.FieldUploadedAt)
 	}
 	return fields
 }
@@ -2372,8 +2412,10 @@ func (m *PictureMutation) Field(name string) (ent.Value, bool) {
 		return m.BodyPart()
 	case picture.FieldKey:
 		return m.Key()
-	case picture.FieldCreatedAt:
-		return m.CreatedAt()
+	case picture.FieldTakenAt:
+		return m.TakenAt()
+	case picture.FieldUploadedAt:
+		return m.UploadedAt()
 	}
 	return nil, false
 }
@@ -2387,8 +2429,10 @@ func (m *PictureMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldBodyPart(ctx)
 	case picture.FieldKey:
 		return m.OldKey(ctx)
-	case picture.FieldCreatedAt:
-		return m.OldCreatedAt(ctx)
+	case picture.FieldTakenAt:
+		return m.OldTakenAt(ctx)
+	case picture.FieldUploadedAt:
+		return m.OldUploadedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown Picture field %s", name)
 }
@@ -2412,12 +2456,19 @@ func (m *PictureMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetKey(v)
 		return nil
-	case picture.FieldCreatedAt:
+	case picture.FieldTakenAt:
 		v, ok := value.(time.Time)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetCreatedAt(v)
+		m.SetTakenAt(v)
+		return nil
+	case picture.FieldUploadedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUploadedAt(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Picture field %s", name)
@@ -2474,8 +2525,11 @@ func (m *PictureMutation) ResetField(name string) error {
 	case picture.FieldKey:
 		m.ResetKey()
 		return nil
-	case picture.FieldCreatedAt:
-		m.ResetCreatedAt()
+	case picture.FieldTakenAt:
+		m.ResetTakenAt()
+		return nil
+	case picture.FieldUploadedAt:
+		m.ResetUploadedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown Picture field %s", name)

--- a/rest-api/ent/mutation.go
+++ b/rest-api/ent/mutation.go
@@ -2259,71 +2259,35 @@ func (m *PictureMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
 }
 
-// TakenAt returns the value of the "taken_at" field in the mutation.
-func (m *PictureMutation) TakenAt() (r time.Time, exists bool) {
-	v := m.taken_at
+// CreatedAt returns the value of the "created_at" field in the mutation.
+func (m *PictureMutation) CreatedAt() (r time.Time, exists bool) {
+	v := m.created_at
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldTakenAt returns the old "taken_at" field's value of the Picture entity.
+// OldCreatedAt returns the old "created_at" field's value of the Picture entity.
 // If the Picture object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PictureMutation) OldTakenAt(ctx context.Context) (v time.Time, err error) {
+func (m *PictureMutation) OldCreatedAt(ctx context.Context) (v time.Time, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, fmt.Errorf("OldTakenAt is only allowed on UpdateOne operations")
+		return v, fmt.Errorf("OldCreatedAt is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, fmt.Errorf("OldTakenAt requires an ID field in the mutation")
+		return v, fmt.Errorf("OldCreatedAt requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldTakenAt: %w", err)
+		return v, fmt.Errorf("querying old value for OldCreatedAt: %w", err)
 	}
-	return oldValue.TakenAt, nil
+	return oldValue.CreatedAt, nil
 }
 
-// ResetTakenAt resets all changes to the "taken_at" field.
-func (m *PictureMutation) ResetTakenAt() {
-	m.taken_at = nil
-}
-
-// SetUploadedAt sets the "uploaded_at" field.
-func (m *PictureMutation) SetUploadedAt(t time.Time) {
-	m.uploaded_at = &t
-}
-
-// UploadedAt returns the value of the "uploaded_at" field in the mutation.
-func (m *PictureMutation) UploadedAt() (r time.Time, exists bool) {
-	v := m.uploaded_at
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldUploadedAt returns the old "uploaded_at" field's value of the Picture entity.
-// If the Picture object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PictureMutation) OldUploadedAt(ctx context.Context) (v time.Time, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, fmt.Errorf("OldUploadedAt is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, fmt.Errorf("OldUploadedAt requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldUploadedAt: %w", err)
-	}
-	return oldValue.UploadedAt, nil
-}
-
-// ResetUploadedAt resets all changes to the "uploaded_at" field.
-func (m *PictureMutation) ResetUploadedAt() {
-	m.uploaded_at = nil
+// ResetCreatedAt resets all changes to the "created_at" field.
+func (m *PictureMutation) ResetCreatedAt() {
+	m.created_at = nil
 }
 
 // SetAlbumID sets the "album" edge to the Album entity by id.
@@ -2436,9 +2400,6 @@ func (m *PictureMutation) Fields() []string {
 	if m.created_at != nil {
 		fields = append(fields, picture.FieldCreatedAt)
 	}
-	if m.uploaded_at != nil {
-		fields = append(fields, picture.FieldUploadedAt)
-	}
 	return fields
 }
 
@@ -2507,14 +2468,7 @@ func (m *PictureMutation) SetField(name string, value ent.Value) error {
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetTakenAt(v)
-		return nil
-	case picture.FieldUploadedAt:
-		v, ok := value.(time.Time)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetUploadedAt(v)
+		m.SetCreatedAt(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Picture field %s", name)
@@ -2576,9 +2530,6 @@ func (m *PictureMutation) ResetField(name string) error {
 		return nil
 	case picture.FieldCreatedAt:
 		m.ResetCreatedAt()
-		return nil
-	case picture.FieldUploadedAt:
-		m.ResetUploadedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown Picture field %s", name)

--- a/rest-api/ent/picture.go
+++ b/rest-api/ent/picture.go
@@ -128,15 +128,9 @@ func (pi *Picture) assignValues(columns []string, values []interface{}) error {
 			}
 		case picture.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
-				return fmt.Errorf("unexpected type %T for field taken_at", values[i])
+				return fmt.Errorf("unexpected type %T for field created_at", values[i])
 			} else if value.Valid {
-				pi.TakenAt = value.Time
-			}
-		case picture.FieldUploadedAt:
-			if value, ok := values[i].(*sql.NullTime); !ok {
-				return fmt.Errorf("unexpected type %T for field uploaded_at", values[i])
-			} else if value.Valid {
-				pi.UploadedAt = value.Time
+				pi.CreatedAt = value.Time
 			}
 		case picture.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {

--- a/rest-api/ent/picture.go
+++ b/rest-api/ent/picture.go
@@ -24,8 +24,8 @@ type Picture struct {
 	Key string `json:"key,omitempty"`
 	// TakenAt holds the value of the "taken_at" field.
 	TakenAt time.Time `json:"taken_at,omitempty"`
-	// UploadedAt holds the value of the "uploaded_at" field.
-	UploadedAt time.Time `json:"uploaded_at,omitempty"`
+	// CreatedAt holds the value of the "created_at" field.
+	CreatedAt time.Time `json:"created_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PictureQuery when eager-loading is set.
 	Edges         PictureEdges `json:"edges"`
@@ -81,7 +81,7 @@ func (*Picture) scanValues(columns []string) ([]interface{}, error) {
 			values[i] = new(sql.NullInt64)
 		case picture.FieldBodyPart, picture.FieldKey:
 			values[i] = new(sql.NullString)
-		case picture.FieldTakenAt, picture.FieldUploadedAt:
+		case picture.FieldTakenAt, picture.FieldCreatedAt:
 			values[i] = new(sql.NullTime)
 		case picture.ForeignKeys[0]: // album_picture
 			values[i] = new(sql.NullInt64)
@@ -121,6 +121,12 @@ func (pi *Picture) assignValues(columns []string, values []interface{}) error {
 				pi.Key = value.String
 			}
 		case picture.FieldTakenAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field taken_at", values[i])
+			} else if value.Valid {
+				pi.TakenAt = value.Time
+			}
+		case picture.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field taken_at", values[i])
 			} else if value.Valid {
@@ -190,8 +196,8 @@ func (pi *Picture) String() string {
 	builder.WriteString(pi.Key)
 	builder.WriteString(", taken_at=")
 	builder.WriteString(pi.TakenAt.Format(time.ANSIC))
-	builder.WriteString(", uploaded_at=")
-	builder.WriteString(pi.UploadedAt.Format(time.ANSIC))
+	builder.WriteString(", created_at=")
+	builder.WriteString(pi.CreatedAt.Format(time.ANSIC))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/rest-api/ent/picture.go
+++ b/rest-api/ent/picture.go
@@ -22,8 +22,10 @@ type Picture struct {
 	BodyPart string `json:"body_part,omitempty"`
 	// Key holds the value of the "key" field.
 	Key string `json:"key,omitempty"`
-	// CreatedAt holds the value of the "created_at" field.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	// TakenAt holds the value of the "taken_at" field.
+	TakenAt time.Time `json:"taken_at,omitempty"`
+	// UploadedAt holds the value of the "uploaded_at" field.
+	UploadedAt time.Time `json:"uploaded_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PictureQuery when eager-loading is set.
 	Edges         PictureEdges `json:"edges"`
@@ -79,7 +81,7 @@ func (*Picture) scanValues(columns []string) ([]interface{}, error) {
 			values[i] = new(sql.NullInt64)
 		case picture.FieldBodyPart, picture.FieldKey:
 			values[i] = new(sql.NullString)
-		case picture.FieldCreatedAt:
+		case picture.FieldTakenAt, picture.FieldUploadedAt:
 			values[i] = new(sql.NullTime)
 		case picture.ForeignKeys[0]: // album_picture
 			values[i] = new(sql.NullInt64)
@@ -118,11 +120,17 @@ func (pi *Picture) assignValues(columns []string, values []interface{}) error {
 			} else if value.Valid {
 				pi.Key = value.String
 			}
-		case picture.FieldCreatedAt:
+		case picture.FieldTakenAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
-				return fmt.Errorf("unexpected type %T for field created_at", values[i])
+				return fmt.Errorf("unexpected type %T for field taken_at", values[i])
 			} else if value.Valid {
-				pi.CreatedAt = value.Time
+				pi.TakenAt = value.Time
+			}
+		case picture.FieldUploadedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field uploaded_at", values[i])
+			} else if value.Valid {
+				pi.UploadedAt = value.Time
 			}
 		case picture.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -180,8 +188,10 @@ func (pi *Picture) String() string {
 	builder.WriteString(pi.BodyPart)
 	builder.WriteString(", key=")
 	builder.WriteString(pi.Key)
-	builder.WriteString(", created_at=")
-	builder.WriteString(pi.CreatedAt.Format(time.ANSIC))
+	builder.WriteString(", taken_at=")
+	builder.WriteString(pi.TakenAt.Format(time.ANSIC))
+	builder.WriteString(", uploaded_at=")
+	builder.WriteString(pi.UploadedAt.Format(time.ANSIC))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/rest-api/ent/picture/picture.go
+++ b/rest-api/ent/picture/picture.go
@@ -17,8 +17,8 @@ const (
 	FieldKey = "key"
 	// FieldTakenAt holds the string denoting the taken_at field in the database.
 	FieldTakenAt = "taken_at"
-	// FieldUploadedAt holds the string denoting the uploaded_at field in the database.
-	FieldUploadedAt = "uploaded_at"
+	// FieldCreatedAt holds the string denoting the created_at field in the database.
+	FieldCreatedAt = "created_at"
 	// EdgeAlbum holds the string denoting the album edge name in mutations.
 	EdgeAlbum = "album"
 	// EdgeUser holds the string denoting the user edge name in mutations.
@@ -47,7 +47,7 @@ var Columns = []string{
 	FieldBodyPart,
 	FieldKey,
 	FieldTakenAt,
-	FieldUploadedAt,
+	FieldCreatedAt,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "pictures"

--- a/rest-api/ent/picture/picture.go
+++ b/rest-api/ent/picture/picture.go
@@ -15,8 +15,10 @@ const (
 	FieldBodyPart = "body_part"
 	// FieldKey holds the string denoting the key field in the database.
 	FieldKey = "key"
-	// FieldCreatedAt holds the string denoting the created_at field in the database.
-	FieldCreatedAt = "created_at"
+	// FieldTakenAt holds the string denoting the taken_at field in the database.
+	FieldTakenAt = "taken_at"
+	// FieldUploadedAt holds the string denoting the uploaded_at field in the database.
+	FieldUploadedAt = "uploaded_at"
 	// EdgeAlbum holds the string denoting the album edge name in mutations.
 	EdgeAlbum = "album"
 	// EdgeUser holds the string denoting the user edge name in mutations.
@@ -44,7 +46,8 @@ var Columns = []string{
 	FieldID,
 	FieldBodyPart,
 	FieldKey,
-	FieldCreatedAt,
+	FieldTakenAt,
+	FieldUploadedAt,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "pictures"
@@ -70,6 +73,6 @@ func ValidColumn(column string) bool {
 }
 
 var (
-	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
-	DefaultCreatedAt func() time.Time
+	// DefaultUploadedAt holds the default value on creation for the "uploaded_at" field.
+	DefaultUploadedAt func() time.Time
 )

--- a/rest-api/ent/picture/picture.go
+++ b/rest-api/ent/picture/picture.go
@@ -73,6 +73,6 @@ func ValidColumn(column string) bool {
 }
 
 var (
-	// DefaultUploadedAt holds the default value on creation for the "uploaded_at" field.
-	DefaultUploadedAt func() time.Time
+	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
+	DefaultCreatedAt func() time.Time
 )

--- a/rest-api/ent/picture/where.go
+++ b/rest-api/ent/picture/where.go
@@ -117,14 +117,7 @@ func TakenAt(v time.Time) predicate.Picture {
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldTakenAt), v))
-	})
-}
-
-// UploadedAt applies equality check predicate on the "uploaded_at" field. It's identical to UploadedAtEQ.
-func UploadedAt(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldUploadedAt), v))
+		s.Where(sql.EQ(s.C(FieldCreatedAt), v))
 	})
 }
 
@@ -429,19 +422,19 @@ func TakenAtLTE(v time.Time) predicate.Picture {
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldTakenAt), v))
+		s.Where(sql.EQ(s.C(FieldCreatedAt), v))
 	})
 }
 
-// TakenAtNEQ applies the NEQ predicate on the "taken_at" field.
-func TakenAtNEQ(v time.Time) predicate.Picture {
+// CreatedAtNEQ applies the NEQ predicate on the "created_at" field.
+func CreatedAtNEQ(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.NEQ(s.C(FieldTakenAt), v))
+		s.Where(sql.NEQ(s.C(FieldCreatedAt), v))
 	})
 }
 
-// TakenAtIn applies the In predicate on the "taken_at" field.
-func TakenAtIn(vs ...time.Time) predicate.Picture {
+// CreatedAtIn applies the In predicate on the "created_at" field.
+func CreatedAtIn(vs ...time.Time) predicate.Picture {
 	v := make([]interface{}, len(vs))
 	for i := range v {
 		v[i] = vs[i]
@@ -453,12 +446,12 @@ func TakenAtIn(vs ...time.Time) predicate.Picture {
 			s.Where(sql.False())
 			return
 		}
-		s.Where(sql.In(s.C(FieldTakenAt), v...))
+		s.Where(sql.In(s.C(FieldCreatedAt), v...))
 	})
 }
 
-// TakenAtNotIn applies the NotIn predicate on the "taken_at" field.
-func TakenAtNotIn(vs ...time.Time) predicate.Picture {
+// CreatedAtNotIn applies the NotIn predicate on the "created_at" field.
+func CreatedAtNotIn(vs ...time.Time) predicate.Picture {
 	v := make([]interface{}, len(vs))
 	for i := range v {
 		v[i] = vs[i]
@@ -470,111 +463,35 @@ func TakenAtNotIn(vs ...time.Time) predicate.Picture {
 			s.Where(sql.False())
 			return
 		}
-		s.Where(sql.NotIn(s.C(FieldTakenAt), v...))
+		s.Where(sql.NotIn(s.C(FieldCreatedAt), v...))
 	})
 }
 
-// TakenAtGT applies the GT predicate on the "taken_at" field.
-func TakenAtGT(v time.Time) predicate.Picture {
+// CreatedAtGT applies the GT predicate on the "created_at" field.
+func CreatedAtGT(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.GT(s.C(FieldTakenAt), v))
+		s.Where(sql.GT(s.C(FieldCreatedAt), v))
 	})
 }
 
-// TakenAtGTE applies the GTE predicate on the "taken_at" field.
-func TakenAtGTE(v time.Time) predicate.Picture {
+// CreatedAtGTE applies the GTE predicate on the "created_at" field.
+func CreatedAtGTE(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.GTE(s.C(FieldTakenAt), v))
+		s.Where(sql.GTE(s.C(FieldCreatedAt), v))
 	})
 }
 
-// TakenAtLT applies the LT predicate on the "taken_at" field.
-func TakenAtLT(v time.Time) predicate.Picture {
+// CreatedAtLT applies the LT predicate on the "created_at" field.
+func CreatedAtLT(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.LT(s.C(FieldTakenAt), v))
+		s.Where(sql.LT(s.C(FieldCreatedAt), v))
 	})
 }
 
-// TakenAtLTE applies the LTE predicate on the "taken_at" field.
-func TakenAtLTE(v time.Time) predicate.Picture {
+// CreatedAtLTE applies the LTE predicate on the "created_at" field.
+func CreatedAtLTE(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.LTE(s.C(FieldTakenAt), v))
-	})
-}
-
-// UploadedAtEQ applies the EQ predicate on the "uploaded_at" field.
-func UploadedAtEQ(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldUploadedAt), v))
-	})
-}
-
-// UploadedAtNEQ applies the NEQ predicate on the "uploaded_at" field.
-func UploadedAtNEQ(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.NEQ(s.C(FieldUploadedAt), v))
-	})
-}
-
-// UploadedAtIn applies the In predicate on the "uploaded_at" field.
-func UploadedAtIn(vs ...time.Time) predicate.Picture {
-	v := make([]interface{}, len(vs))
-	for i := range v {
-		v[i] = vs[i]
-	}
-	return predicate.Picture(func(s *sql.Selector) {
-		// if not arguments were provided, append the FALSE constants,
-		// since we can't apply "IN ()". This will make this predicate falsy.
-		if len(v) == 0 {
-			s.Where(sql.False())
-			return
-		}
-		s.Where(sql.In(s.C(FieldUploadedAt), v...))
-	})
-}
-
-// UploadedAtNotIn applies the NotIn predicate on the "uploaded_at" field.
-func UploadedAtNotIn(vs ...time.Time) predicate.Picture {
-	v := make([]interface{}, len(vs))
-	for i := range v {
-		v[i] = vs[i]
-	}
-	return predicate.Picture(func(s *sql.Selector) {
-		// if not arguments were provided, append the FALSE constants,
-		// since we can't apply "IN ()". This will make this predicate falsy.
-		if len(v) == 0 {
-			s.Where(sql.False())
-			return
-		}
-		s.Where(sql.NotIn(s.C(FieldUploadedAt), v...))
-	})
-}
-
-// UploadedAtGT applies the GT predicate on the "uploaded_at" field.
-func UploadedAtGT(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.GT(s.C(FieldUploadedAt), v))
-	})
-}
-
-// UploadedAtGTE applies the GTE predicate on the "uploaded_at" field.
-func UploadedAtGTE(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.GTE(s.C(FieldUploadedAt), v))
-	})
-}
-
-// UploadedAtLT applies the LT predicate on the "uploaded_at" field.
-func UploadedAtLT(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.LT(s.C(FieldUploadedAt), v))
-	})
-}
-
-// UploadedAtLTE applies the LTE predicate on the "uploaded_at" field.
-func UploadedAtLTE(v time.Time) predicate.Picture {
-	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.LTE(s.C(FieldUploadedAt), v))
+		s.Where(sql.LTE(s.C(FieldCreatedAt), v))
 	})
 }
 

--- a/rest-api/ent/picture/where.go
+++ b/rest-api/ent/picture/where.go
@@ -107,10 +107,17 @@ func Key(v string) predicate.Picture {
 	})
 }
 
-// CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
-func CreatedAt(v time.Time) predicate.Picture {
+// TakenAt applies equality check predicate on the "taken_at" field. It's identical to TakenAtEQ.
+func TakenAt(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldCreatedAt), v))
+		s.Where(sql.EQ(s.C(FieldTakenAt), v))
+	})
+}
+
+// UploadedAt applies equality check predicate on the "uploaded_at" field. It's identical to UploadedAtEQ.
+func UploadedAt(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldUploadedAt), v))
 	})
 }
 
@@ -336,22 +343,22 @@ func KeyContainsFold(v string) predicate.Picture {
 	})
 }
 
-// CreatedAtEQ applies the EQ predicate on the "created_at" field.
-func CreatedAtEQ(v time.Time) predicate.Picture {
+// TakenAtEQ applies the EQ predicate on the "taken_at" field.
+func TakenAtEQ(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldCreatedAt), v))
+		s.Where(sql.EQ(s.C(FieldTakenAt), v))
 	})
 }
 
-// CreatedAtNEQ applies the NEQ predicate on the "created_at" field.
-func CreatedAtNEQ(v time.Time) predicate.Picture {
+// TakenAtNEQ applies the NEQ predicate on the "taken_at" field.
+func TakenAtNEQ(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.NEQ(s.C(FieldCreatedAt), v))
+		s.Where(sql.NEQ(s.C(FieldTakenAt), v))
 	})
 }
 
-// CreatedAtIn applies the In predicate on the "created_at" field.
-func CreatedAtIn(vs ...time.Time) predicate.Picture {
+// TakenAtIn applies the In predicate on the "taken_at" field.
+func TakenAtIn(vs ...time.Time) predicate.Picture {
 	v := make([]interface{}, len(vs))
 	for i := range v {
 		v[i] = vs[i]
@@ -363,12 +370,12 @@ func CreatedAtIn(vs ...time.Time) predicate.Picture {
 			s.Where(sql.False())
 			return
 		}
-		s.Where(sql.In(s.C(FieldCreatedAt), v...))
+		s.Where(sql.In(s.C(FieldTakenAt), v...))
 	})
 }
 
-// CreatedAtNotIn applies the NotIn predicate on the "created_at" field.
-func CreatedAtNotIn(vs ...time.Time) predicate.Picture {
+// TakenAtNotIn applies the NotIn predicate on the "taken_at" field.
+func TakenAtNotIn(vs ...time.Time) predicate.Picture {
 	v := make([]interface{}, len(vs))
 	for i := range v {
 		v[i] = vs[i]
@@ -380,35 +387,111 @@ func CreatedAtNotIn(vs ...time.Time) predicate.Picture {
 			s.Where(sql.False())
 			return
 		}
-		s.Where(sql.NotIn(s.C(FieldCreatedAt), v...))
+		s.Where(sql.NotIn(s.C(FieldTakenAt), v...))
 	})
 }
 
-// CreatedAtGT applies the GT predicate on the "created_at" field.
-func CreatedAtGT(v time.Time) predicate.Picture {
+// TakenAtGT applies the GT predicate on the "taken_at" field.
+func TakenAtGT(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.GT(s.C(FieldCreatedAt), v))
+		s.Where(sql.GT(s.C(FieldTakenAt), v))
 	})
 }
 
-// CreatedAtGTE applies the GTE predicate on the "created_at" field.
-func CreatedAtGTE(v time.Time) predicate.Picture {
+// TakenAtGTE applies the GTE predicate on the "taken_at" field.
+func TakenAtGTE(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.GTE(s.C(FieldCreatedAt), v))
+		s.Where(sql.GTE(s.C(FieldTakenAt), v))
 	})
 }
 
-// CreatedAtLT applies the LT predicate on the "created_at" field.
-func CreatedAtLT(v time.Time) predicate.Picture {
+// TakenAtLT applies the LT predicate on the "taken_at" field.
+func TakenAtLT(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.LT(s.C(FieldCreatedAt), v))
+		s.Where(sql.LT(s.C(FieldTakenAt), v))
 	})
 }
 
-// CreatedAtLTE applies the LTE predicate on the "created_at" field.
-func CreatedAtLTE(v time.Time) predicate.Picture {
+// TakenAtLTE applies the LTE predicate on the "taken_at" field.
+func TakenAtLTE(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
-		s.Where(sql.LTE(s.C(FieldCreatedAt), v))
+		s.Where(sql.LTE(s.C(FieldTakenAt), v))
+	})
+}
+
+// UploadedAtEQ applies the EQ predicate on the "uploaded_at" field.
+func UploadedAtEQ(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldUploadedAt), v))
+	})
+}
+
+// UploadedAtNEQ applies the NEQ predicate on the "uploaded_at" field.
+func UploadedAtNEQ(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldUploadedAt), v))
+	})
+}
+
+// UploadedAtIn applies the In predicate on the "uploaded_at" field.
+func UploadedAtIn(vs ...time.Time) predicate.Picture {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Picture(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldUploadedAt), v...))
+	})
+}
+
+// UploadedAtNotIn applies the NotIn predicate on the "uploaded_at" field.
+func UploadedAtNotIn(vs ...time.Time) predicate.Picture {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Picture(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldUploadedAt), v...))
+	})
+}
+
+// UploadedAtGT applies the GT predicate on the "uploaded_at" field.
+func UploadedAtGT(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldUploadedAt), v))
+	})
+}
+
+// UploadedAtGTE applies the GTE predicate on the "uploaded_at" field.
+func UploadedAtGTE(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldUploadedAt), v))
+	})
+}
+
+// UploadedAtLT applies the LT predicate on the "uploaded_at" field.
+func UploadedAtLT(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldUploadedAt), v))
+	})
+}
+
+// UploadedAtLTE applies the LTE predicate on the "uploaded_at" field.
+func UploadedAtLTE(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldUploadedAt), v))
 	})
 }
 

--- a/rest-api/ent/picture/where.go
+++ b/rest-api/ent/picture/where.go
@@ -114,6 +114,13 @@ func TakenAt(v time.Time) predicate.Picture {
 	})
 }
 
+// CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
+func CreatedAt(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldTakenAt), v))
+	})
+}
+
 // UploadedAt applies equality check predicate on the "uploaded_at" field. It's identical to UploadedAtEQ.
 func UploadedAt(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
@@ -345,6 +352,82 @@ func KeyContainsFold(v string) predicate.Picture {
 
 // TakenAtEQ applies the EQ predicate on the "taken_at" field.
 func TakenAtEQ(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldTakenAt), v))
+	})
+}
+
+// TakenAtNEQ applies the NEQ predicate on the "taken_at" field.
+func TakenAtNEQ(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldTakenAt), v))
+	})
+}
+
+// TakenAtIn applies the In predicate on the "taken_at" field.
+func TakenAtIn(vs ...time.Time) predicate.Picture {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Picture(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldTakenAt), v...))
+	})
+}
+
+// TakenAtNotIn applies the NotIn predicate on the "taken_at" field.
+func TakenAtNotIn(vs ...time.Time) predicate.Picture {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Picture(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldTakenAt), v...))
+	})
+}
+
+// TakenAtGT applies the GT predicate on the "taken_at" field.
+func TakenAtGT(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldTakenAt), v))
+	})
+}
+
+// TakenAtGTE applies the GTE predicate on the "taken_at" field.
+func TakenAtGTE(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldTakenAt), v))
+	})
+}
+
+// TakenAtLT applies the LT predicate on the "taken_at" field.
+func TakenAtLT(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldTakenAt), v))
+	})
+}
+
+// TakenAtLTE applies the LTE predicate on the "taken_at" field.
+func TakenAtLTE(v time.Time) predicate.Picture {
+	return predicate.Picture(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldTakenAt), v))
+	})
+}
+
+// CreatedAtEQ applies the EQ predicate on the "created_at" field.
+func CreatedAtEQ(v time.Time) predicate.Picture {
 	return predicate.Picture(func(s *sql.Selector) {
 		s.Where(sql.EQ(s.C(FieldTakenAt), v))
 	})

--- a/rest-api/ent/picture_create.go
+++ b/rest-api/ent/picture_create.go
@@ -40,6 +40,12 @@ func (pc *PictureCreate) SetTakenAt(t time.Time) *PictureCreate {
 	return pc
 }
 
+// SetCreatedAt sets the "created_at" field.
+func (pc *PictureCreate) SetCreatedAt(t time.Time) *PictureCreate {
+	pc.mutation.SetCreatedAt(t)
+	return pc
+}
+
 // SetUploadedAt sets the "uploaded_at" field.
 func (pc *PictureCreate) SetUploadedAt(t time.Time) *PictureCreate {
 	pc.mutation.SetUploadedAt(t)
@@ -172,6 +178,9 @@ func (pc *PictureCreate) check() error {
 	if _, ok := pc.mutation.TakenAt(); !ok {
 		return &ValidationError{Name: "taken_at", err: errors.New(`ent: missing required field "taken_at"`)}
 	}
+	if _, ok := pc.mutation.CreatedAt(); !ok {
+		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "created_at"`)}
+	}
 	if _, ok := pc.mutation.UploadedAt(); !ok {
 		return &ValidationError{Name: "uploaded_at", err: errors.New(`ent: missing required field "uploaded_at"`)}
 	}
@@ -222,6 +231,14 @@ func (pc *PictureCreate) createSpec() (*Picture, *sqlgraph.CreateSpec) {
 		_node.Key = value
 	}
 	if value, ok := pc.mutation.TakenAt(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeTime,
+			Value:  value,
+			Column: picture.FieldTakenAt,
+		})
+		_node.TakenAt = value
+	}
+	if value, ok := pc.mutation.CreatedAt(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,

--- a/rest-api/ent/picture_create.go
+++ b/rest-api/ent/picture_create.go
@@ -46,16 +46,10 @@ func (pc *PictureCreate) SetCreatedAt(t time.Time) *PictureCreate {
 	return pc
 }
 
-// SetUploadedAt sets the "uploaded_at" field.
-func (pc *PictureCreate) SetUploadedAt(t time.Time) *PictureCreate {
-	pc.mutation.SetUploadedAt(t)
-	return pc
-}
-
-// SetNillableUploadedAt sets the "uploaded_at" field if the given value is not nil.
-func (pc *PictureCreate) SetNillableUploadedAt(t *time.Time) *PictureCreate {
+// SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
+func (pc *PictureCreate) SetNillableCreatedAt(t *time.Time) *PictureCreate {
 	if t != nil {
-		pc.SetUploadedAt(*t)
+		pc.SetCreatedAt(*t)
 	}
 	return pc
 }
@@ -161,9 +155,9 @@ func (pc *PictureCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (pc *PictureCreate) defaults() {
-	if _, ok := pc.mutation.UploadedAt(); !ok {
-		v := picture.DefaultUploadedAt()
-		pc.mutation.SetUploadedAt(v)
+	if _, ok := pc.mutation.CreatedAt(); !ok {
+		v := picture.DefaultCreatedAt()
+		pc.mutation.SetCreatedAt(v)
 	}
 }
 
@@ -180,9 +174,6 @@ func (pc *PictureCreate) check() error {
 	}
 	if _, ok := pc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "created_at"`)}
-	}
-	if _, ok := pc.mutation.UploadedAt(); !ok {
-		return &ValidationError{Name: "uploaded_at", err: errors.New(`ent: missing required field "uploaded_at"`)}
 	}
 	if _, ok := pc.mutation.UserID(); !ok {
 		return &ValidationError{Name: "user", err: errors.New("ent: missing required edge \"user\"")}
@@ -242,17 +233,9 @@ func (pc *PictureCreate) createSpec() (*Picture, *sqlgraph.CreateSpec) {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,
-			Column: picture.FieldTakenAt,
+			Column: picture.FieldCreatedAt,
 		})
-		_node.TakenAt = value
-	}
-	if value, ok := pc.mutation.UploadedAt(); ok {
-		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
-			Type:   field.TypeTime,
-			Value:  value,
-			Column: picture.FieldUploadedAt,
-		})
-		_node.UploadedAt = value
+		_node.CreatedAt = value
 	}
 	if nodes := pc.mutation.AlbumIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/rest-api/ent/picture_create.go
+++ b/rest-api/ent/picture_create.go
@@ -34,16 +34,22 @@ func (pc *PictureCreate) SetKey(s string) *PictureCreate {
 	return pc
 }
 
-// SetCreatedAt sets the "created_at" field.
-func (pc *PictureCreate) SetCreatedAt(t time.Time) *PictureCreate {
-	pc.mutation.SetCreatedAt(t)
+// SetTakenAt sets the "taken_at" field.
+func (pc *PictureCreate) SetTakenAt(t time.Time) *PictureCreate {
+	pc.mutation.SetTakenAt(t)
 	return pc
 }
 
-// SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
-func (pc *PictureCreate) SetNillableCreatedAt(t *time.Time) *PictureCreate {
+// SetUploadedAt sets the "uploaded_at" field.
+func (pc *PictureCreate) SetUploadedAt(t time.Time) *PictureCreate {
+	pc.mutation.SetUploadedAt(t)
+	return pc
+}
+
+// SetNillableUploadedAt sets the "uploaded_at" field if the given value is not nil.
+func (pc *PictureCreate) SetNillableUploadedAt(t *time.Time) *PictureCreate {
 	if t != nil {
-		pc.SetCreatedAt(*t)
+		pc.SetUploadedAt(*t)
 	}
 	return pc
 }
@@ -149,9 +155,9 @@ func (pc *PictureCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (pc *PictureCreate) defaults() {
-	if _, ok := pc.mutation.CreatedAt(); !ok {
-		v := picture.DefaultCreatedAt()
-		pc.mutation.SetCreatedAt(v)
+	if _, ok := pc.mutation.UploadedAt(); !ok {
+		v := picture.DefaultUploadedAt()
+		pc.mutation.SetUploadedAt(v)
 	}
 }
 
@@ -163,8 +169,11 @@ func (pc *PictureCreate) check() error {
 	if _, ok := pc.mutation.Key(); !ok {
 		return &ValidationError{Name: "key", err: errors.New(`ent: missing required field "key"`)}
 	}
-	if _, ok := pc.mutation.CreatedAt(); !ok {
-		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "created_at"`)}
+	if _, ok := pc.mutation.TakenAt(); !ok {
+		return &ValidationError{Name: "taken_at", err: errors.New(`ent: missing required field "taken_at"`)}
+	}
+	if _, ok := pc.mutation.UploadedAt(); !ok {
+		return &ValidationError{Name: "uploaded_at", err: errors.New(`ent: missing required field "uploaded_at"`)}
 	}
 	if _, ok := pc.mutation.UserID(); !ok {
 		return &ValidationError{Name: "user", err: errors.New("ent: missing required edge \"user\"")}
@@ -212,13 +221,21 @@ func (pc *PictureCreate) createSpec() (*Picture, *sqlgraph.CreateSpec) {
 		})
 		_node.Key = value
 	}
-	if value, ok := pc.mutation.CreatedAt(); ok {
+	if value, ok := pc.mutation.TakenAt(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,
-			Column: picture.FieldCreatedAt,
+			Column: picture.FieldTakenAt,
 		})
-		_node.CreatedAt = value
+		_node.TakenAt = value
+	}
+	if value, ok := pc.mutation.UploadedAt(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeTime,
+			Value:  value,
+			Column: picture.FieldUploadedAt,
+		})
+		_node.UploadedAt = value
 	}
 	if nodes := pc.mutation.AlbumIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/rest-api/ent/picture_update.go
+++ b/rest-api/ent/picture_update.go
@@ -48,6 +48,12 @@ func (pu *PictureUpdate) SetTakenAt(t time.Time) *PictureUpdate {
 	return pu
 }
 
+// SetCreatedAt sets the "created_at" field.
+func (pu *PictureUpdate) SetCreatedAt(t time.Time) *PictureUpdate {
+	pu.mutation.SetCreatedAt(t)
+	return pu
+}
+
 // SetUploadedAt sets the "uploaded_at" field.
 func (pu *PictureUpdate) SetUploadedAt(t time.Time) *PictureUpdate {
 	pu.mutation.SetUploadedAt(t)
@@ -216,6 +222,13 @@ func (pu *PictureUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: picture.FieldTakenAt,
 		})
 	}
+	if value, ok := pu.mutation.CreatedAt(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeTime,
+			Value:  value,
+			Column: picture.FieldTakenAt,
+		})
+	}
 	if value, ok := pu.mutation.UploadedAt(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
@@ -327,6 +340,12 @@ func (puo *PictureUpdateOne) SetKey(s string) *PictureUpdateOne {
 // SetTakenAt sets the "taken_at" field.
 func (puo *PictureUpdateOne) SetTakenAt(t time.Time) *PictureUpdateOne {
 	puo.mutation.SetTakenAt(t)
+	return puo
+}
+
+// SetCreatedAt sets the "created_at" field.
+func (puo *PictureUpdateOne) SetCreatedAt(t time.Time) *PictureUpdateOne {
+	puo.mutation.SetCreatedAt(t)
 	return puo
 }
 
@@ -516,6 +535,13 @@ func (puo *PictureUpdateOne) sqlSave(ctx context.Context) (_node *Picture, err e
 		})
 	}
 	if value, ok := puo.mutation.TakenAt(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeTime,
+			Value:  value,
+			Column: picture.FieldTakenAt,
+		})
+	}
+	if value, ok := puo.mutation.CreatedAt(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,

--- a/rest-api/ent/picture_update.go
+++ b/rest-api/ent/picture_update.go
@@ -54,16 +54,10 @@ func (pu *PictureUpdate) SetCreatedAt(t time.Time) *PictureUpdate {
 	return pu
 }
 
-// SetUploadedAt sets the "uploaded_at" field.
-func (pu *PictureUpdate) SetUploadedAt(t time.Time) *PictureUpdate {
-	pu.mutation.SetUploadedAt(t)
-	return pu
-}
-
-// SetNillableUploadedAt sets the "uploaded_at" field if the given value is not nil.
-func (pu *PictureUpdate) SetNillableUploadedAt(t *time.Time) *PictureUpdate {
+// SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
+func (pu *PictureUpdate) SetNillableCreatedAt(t *time.Time) *PictureUpdate {
 	if t != nil {
-		pu.SetUploadedAt(*t)
+		pu.SetCreatedAt(*t)
 	}
 	return pu
 }
@@ -226,14 +220,7 @@ func (pu *PictureUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,
-			Column: picture.FieldTakenAt,
-		})
-	}
-	if value, ok := pu.mutation.UploadedAt(); ok {
-		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
-			Type:   field.TypeTime,
-			Value:  value,
-			Column: picture.FieldUploadedAt,
+			Column: picture.FieldCreatedAt,
 		})
 	}
 	if pu.mutation.AlbumCleared() {
@@ -349,16 +336,10 @@ func (puo *PictureUpdateOne) SetCreatedAt(t time.Time) *PictureUpdateOne {
 	return puo
 }
 
-// SetUploadedAt sets the "uploaded_at" field.
-func (puo *PictureUpdateOne) SetUploadedAt(t time.Time) *PictureUpdateOne {
-	puo.mutation.SetUploadedAt(t)
-	return puo
-}
-
-// SetNillableUploadedAt sets the "uploaded_at" field if the given value is not nil.
-func (puo *PictureUpdateOne) SetNillableUploadedAt(t *time.Time) *PictureUpdateOne {
+// SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
+func (puo *PictureUpdateOne) SetNillableCreatedAt(t *time.Time) *PictureUpdateOne {
 	if t != nil {
-		puo.SetUploadedAt(*t)
+		puo.SetCreatedAt(*t)
 	}
 	return puo
 }
@@ -545,14 +526,7 @@ func (puo *PictureUpdateOne) sqlSave(ctx context.Context) (_node *Picture, err e
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,
-			Column: picture.FieldTakenAt,
-		})
-	}
-	if value, ok := puo.mutation.UploadedAt(); ok {
-		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
-			Type:   field.TypeTime,
-			Value:  value,
-			Column: picture.FieldUploadedAt,
+			Column: picture.FieldCreatedAt,
 		})
 	}
 	if puo.mutation.AlbumCleared() {

--- a/rest-api/ent/picture_update.go
+++ b/rest-api/ent/picture_update.go
@@ -42,16 +42,22 @@ func (pu *PictureUpdate) SetKey(s string) *PictureUpdate {
 	return pu
 }
 
-// SetCreatedAt sets the "created_at" field.
-func (pu *PictureUpdate) SetCreatedAt(t time.Time) *PictureUpdate {
-	pu.mutation.SetCreatedAt(t)
+// SetTakenAt sets the "taken_at" field.
+func (pu *PictureUpdate) SetTakenAt(t time.Time) *PictureUpdate {
+	pu.mutation.SetTakenAt(t)
 	return pu
 }
 
-// SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
-func (pu *PictureUpdate) SetNillableCreatedAt(t *time.Time) *PictureUpdate {
+// SetUploadedAt sets the "uploaded_at" field.
+func (pu *PictureUpdate) SetUploadedAt(t time.Time) *PictureUpdate {
+	pu.mutation.SetUploadedAt(t)
+	return pu
+}
+
+// SetNillableUploadedAt sets the "uploaded_at" field if the given value is not nil.
+func (pu *PictureUpdate) SetNillableUploadedAt(t *time.Time) *PictureUpdate {
 	if t != nil {
-		pu.SetCreatedAt(*t)
+		pu.SetUploadedAt(*t)
 	}
 	return pu
 }
@@ -203,11 +209,18 @@ func (pu *PictureUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: picture.FieldKey,
 		})
 	}
-	if value, ok := pu.mutation.CreatedAt(); ok {
+	if value, ok := pu.mutation.TakenAt(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,
-			Column: picture.FieldCreatedAt,
+			Column: picture.FieldTakenAt,
+		})
+	}
+	if value, ok := pu.mutation.UploadedAt(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeTime,
+			Value:  value,
+			Column: picture.FieldUploadedAt,
 		})
 	}
 	if pu.mutation.AlbumCleared() {
@@ -311,16 +324,22 @@ func (puo *PictureUpdateOne) SetKey(s string) *PictureUpdateOne {
 	return puo
 }
 
-// SetCreatedAt sets the "created_at" field.
-func (puo *PictureUpdateOne) SetCreatedAt(t time.Time) *PictureUpdateOne {
-	puo.mutation.SetCreatedAt(t)
+// SetTakenAt sets the "taken_at" field.
+func (puo *PictureUpdateOne) SetTakenAt(t time.Time) *PictureUpdateOne {
+	puo.mutation.SetTakenAt(t)
 	return puo
 }
 
-// SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
-func (puo *PictureUpdateOne) SetNillableCreatedAt(t *time.Time) *PictureUpdateOne {
+// SetUploadedAt sets the "uploaded_at" field.
+func (puo *PictureUpdateOne) SetUploadedAt(t time.Time) *PictureUpdateOne {
+	puo.mutation.SetUploadedAt(t)
+	return puo
+}
+
+// SetNillableUploadedAt sets the "uploaded_at" field if the given value is not nil.
+func (puo *PictureUpdateOne) SetNillableUploadedAt(t *time.Time) *PictureUpdateOne {
 	if t != nil {
-		puo.SetCreatedAt(*t)
+		puo.SetUploadedAt(*t)
 	}
 	return puo
 }
@@ -496,11 +515,18 @@ func (puo *PictureUpdateOne) sqlSave(ctx context.Context) (_node *Picture, err e
 			Column: picture.FieldKey,
 		})
 	}
-	if value, ok := puo.mutation.CreatedAt(); ok {
+	if value, ok := puo.mutation.TakenAt(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  value,
-			Column: picture.FieldCreatedAt,
+			Column: picture.FieldTakenAt,
+		})
+	}
+	if value, ok := puo.mutation.UploadedAt(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeTime,
+			Value:  value,
+			Column: picture.FieldUploadedAt,
 		})
 	}
 	if puo.mutation.AlbumCleared() {

--- a/rest-api/ent/runtime.go
+++ b/rest-api/ent/runtime.go
@@ -59,10 +59,10 @@ func init() {
 	notificationconfig.DefaultIsActivated = notificationconfigDescIsActivated.Default.(bool)
 	pictureFields := schema.Picture{}.Fields()
 	_ = pictureFields
-	// pictureDescUploadedAt is the schema descriptor for uploaded_at field.
-	pictureDescUploadedAt := pictureFields[3].Descriptor()
-	// picture.DefaultUploadedAt holds the default value on creation for the uploaded_at field.
-	picture.DefaultUploadedAt = pictureDescUploadedAt.Default.(func() time.Time)
+	// pictureDescCreatedAt is the schema descriptor for created_at field.
+	pictureDescCreatedAt := pictureFields[3].Descriptor()
+	// picture.DefaultCreatedAt holds the default value on creation for the created_at field.
+	picture.DefaultCreatedAt = pictureDescCreatedAt.Default.(func() time.Time)
 	userFields := schema.User{}.Fields()
 	_ = userFields
 	// userDescMotto is the schema descriptor for motto field.

--- a/rest-api/ent/runtime.go
+++ b/rest-api/ent/runtime.go
@@ -59,10 +59,10 @@ func init() {
 	notificationconfig.DefaultIsActivated = notificationconfigDescIsActivated.Default.(bool)
 	pictureFields := schema.Picture{}.Fields()
 	_ = pictureFields
-	// pictureDescCreatedAt is the schema descriptor for created_at field.
-	pictureDescCreatedAt := pictureFields[2].Descriptor()
-	// picture.DefaultCreatedAt holds the default value on creation for the created_at field.
-	picture.DefaultCreatedAt = pictureDescCreatedAt.Default.(func() time.Time)
+	// pictureDescUploadedAt is the schema descriptor for uploaded_at field.
+	pictureDescUploadedAt := pictureFields[3].Descriptor()
+	// picture.DefaultUploadedAt holds the default value on creation for the uploaded_at field.
+	picture.DefaultUploadedAt = pictureDescUploadedAt.Default.(func() time.Time)
 	userFields := schema.User{}.Fields()
 	_ = userFields
 	// userDescMotto is the schema descriptor for motto field.

--- a/rest-api/ent/runtime.go
+++ b/rest-api/ent/runtime.go
@@ -66,11 +66,11 @@ func init() {
 	userFields := schema.User{}.Fields()
 	_ = userFields
 	// userDescMotto is the schema descriptor for motto field.
-	userDescMotto := userFields[2].Descriptor()
+	userDescMotto := userFields[3].Descriptor()
 	// user.DefaultMotto holds the default value on creation for the motto field.
 	user.DefaultMotto = userDescMotto.Default.(string)
 	// userDescCreatedAt is the schema descriptor for created_at field.
-	userDescCreatedAt := userFields[6].Descriptor()
+	userDescCreatedAt := userFields[7].Descriptor()
 	// user.DefaultCreatedAt holds the default value on creation for the created_at field.
 	user.DefaultCreatedAt = userDescCreatedAt.Default.(func() time.Time)
 	videoFields := schema.Video{}.Fields()

--- a/rest-api/ent/schema/picture.go
+++ b/rest-api/ent/schema/picture.go
@@ -17,9 +17,11 @@ type Picture struct {
 func (Picture) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("body_part"),
-		// TODO: 이 부분은 location보다는 key가 좋을 것 같은데 어떨까요
 		field.String("key"),
-		field.Time("created_at").Default(func() time.Time {
+		// taken_at은 사진을 찍은 날짜
+		field.Time("taken_at"),
+		// uploaded_at은 사진을 서버로 업로드한 날짜
+		field.Time("uploaded_at").Default(func() time.Time {
 			return time.Now()
 		}),
 	}

--- a/rest-api/ent/schema/picture.go
+++ b/rest-api/ent/schema/picture.go
@@ -18,10 +18,8 @@ func (Picture) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("body_part"),
 		field.String("key"),
-		// taken_at은 사진을 찍은 날짜
 		field.Time("taken_at"),
-		// uploaded_at은 사진을 서버로 업로드한 날짜
-		field.Time("uploaded_at").Default(func() time.Time {
+		field.Time("created_at").Default(func() time.Time {
 			return time.Now()
 		}),
 	}

--- a/rest-api/ent/schema/user.go
+++ b/rest-api/ent/schema/user.go
@@ -19,6 +19,7 @@ type User struct {
 func (User) Fields() []ent.Field {
 	return []ent.Field{
 		field.Int("id"),
+		field.String("profile_image").Optional(),
 		field.String("nickname"),
 		field.String("motto").Default("눈바디와 함께 꾸준히 운동할테야!"),
 		field.Int("height").Optional().Nillable(),

--- a/rest-api/ent/user.go
+++ b/rest-api/ent/user.go
@@ -16,6 +16,8 @@ type User struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID int `json:"id,omitempty"`
+	// ProfileImage holds the value of the "profile_image" field.
+	ProfileImage string `json:"profile_image,omitempty"`
 	// Nickname holds the value of the "nickname" field.
 	Nickname string `json:"nickname,omitempty"`
 	// Motto holds the value of the "motto" field.
@@ -102,7 +104,7 @@ func (*User) scanValues(columns []string) ([]interface{}, error) {
 		switch columns[i] {
 		case user.FieldID, user.FieldHeight, user.FieldWeight:
 			values[i] = new(sql.NullInt64)
-		case user.FieldNickname, user.FieldMotto, user.FieldKind:
+		case user.FieldProfileImage, user.FieldNickname, user.FieldMotto, user.FieldKind:
 			values[i] = new(sql.NullString)
 		case user.FieldCreatedAt:
 			values[i] = new(sql.NullTime)
@@ -127,6 +129,12 @@ func (u *User) assignValues(columns []string, values []interface{}) error {
 				return fmt.Errorf("unexpected type %T for field id", value)
 			}
 			u.ID = int(value.Int64)
+		case user.FieldProfileImage:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field profile_image", values[i])
+			} else if value.Valid {
+				u.ProfileImage = value.String
+			}
 		case user.FieldNickname:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field nickname", values[i])
@@ -218,6 +226,8 @@ func (u *User) String() string {
 	var builder strings.Builder
 	builder.WriteString("User(")
 	builder.WriteString(fmt.Sprintf("id=%v", u.ID))
+	builder.WriteString(", profile_image=")
+	builder.WriteString(u.ProfileImage)
 	builder.WriteString(", nickname=")
 	builder.WriteString(u.Nickname)
 	builder.WriteString(", motto=")

--- a/rest-api/ent/user/user.go
+++ b/rest-api/ent/user/user.go
@@ -12,6 +12,8 @@ const (
 	Label = "user"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldProfileImage holds the string denoting the profile_image field in the database.
+	FieldProfileImage = "profile_image"
 	// FieldNickname holds the string denoting the nickname field in the database.
 	FieldNickname = "nickname"
 	// FieldMotto holds the string denoting the motto field in the database.
@@ -76,6 +78,7 @@ const (
 // Columns holds all SQL columns for user fields.
 var Columns = []string{
 	FieldID,
+	FieldProfileImage,
 	FieldNickname,
 	FieldMotto,
 	FieldHeight,

--- a/rest-api/ent/user/where.go
+++ b/rest-api/ent/user/where.go
@@ -93,6 +93,13 @@ func IDLTE(id int) predicate.User {
 	})
 }
 
+// ProfileImage applies equality check predicate on the "profile_image" field. It's identical to ProfileImageEQ.
+func ProfileImage(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldProfileImage), v))
+	})
+}
+
 // Nickname applies equality check predicate on the "nickname" field. It's identical to NicknameEQ.
 func Nickname(v string) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
@@ -125,6 +132,131 @@ func Weight(v int) predicate.User {
 func CreatedAt(v time.Time) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
 		s.Where(sql.EQ(s.C(FieldCreatedAt), v))
+	})
+}
+
+// ProfileImageEQ applies the EQ predicate on the "profile_image" field.
+func ProfileImageEQ(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageNEQ applies the NEQ predicate on the "profile_image" field.
+func ProfileImageNEQ(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageIn applies the In predicate on the "profile_image" field.
+func ProfileImageIn(vs ...string) predicate.User {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldProfileImage), v...))
+	})
+}
+
+// ProfileImageNotIn applies the NotIn predicate on the "profile_image" field.
+func ProfileImageNotIn(vs ...string) predicate.User {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldProfileImage), v...))
+	})
+}
+
+// ProfileImageGT applies the GT predicate on the "profile_image" field.
+func ProfileImageGT(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageGTE applies the GTE predicate on the "profile_image" field.
+func ProfileImageGTE(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageLT applies the LT predicate on the "profile_image" field.
+func ProfileImageLT(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageLTE applies the LTE predicate on the "profile_image" field.
+func ProfileImageLTE(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageContains applies the Contains predicate on the "profile_image" field.
+func ProfileImageContains(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageHasPrefix applies the HasPrefix predicate on the "profile_image" field.
+func ProfileImageHasPrefix(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageHasSuffix applies the HasSuffix predicate on the "profile_image" field.
+func ProfileImageHasSuffix(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageIsNil applies the IsNil predicate on the "profile_image" field.
+func ProfileImageIsNil() predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldProfileImage)))
+	})
+}
+
+// ProfileImageNotNil applies the NotNil predicate on the "profile_image" field.
+func ProfileImageNotNil() predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldProfileImage)))
+	})
+}
+
+// ProfileImageEqualFold applies the EqualFold predicate on the "profile_image" field.
+func ProfileImageEqualFold(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageContainsFold applies the ContainsFold predicate on the "profile_image" field.
+func ProfileImageContainsFold(v string) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldProfileImage), v))
 	})
 }
 

--- a/rest-api/ent/user_create.go
+++ b/rest-api/ent/user_create.go
@@ -25,6 +25,20 @@ type UserCreate struct {
 	hooks    []Hook
 }
 
+// SetProfileImage sets the "profile_image" field.
+func (uc *UserCreate) SetProfileImage(s string) *UserCreate {
+	uc.mutation.SetProfileImage(s)
+	return uc
+}
+
+// SetNillableProfileImage sets the "profile_image" field if the given value is not nil.
+func (uc *UserCreate) SetNillableProfileImage(s *string) *UserCreate {
+	if s != nil {
+		uc.SetProfileImage(*s)
+	}
+	return uc
+}
+
 // SetNickname sets the "nickname" field.
 func (uc *UserCreate) SetNickname(s string) *UserCreate {
 	uc.mutation.SetNickname(s)
@@ -306,6 +320,14 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if id, ok := uc.mutation.ID(); ok {
 		_node.ID = id
 		_spec.ID.Value = id
+	}
+	if value, ok := uc.mutation.ProfileImage(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: user.FieldProfileImage,
+		})
+		_node.ProfileImage = value
 	}
 	if value, ok := uc.mutation.Nickname(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{

--- a/rest-api/ent/user_query.go
+++ b/rest-api/ent/user_query.go
@@ -435,12 +435,12 @@ func (uq *UserQuery) WithVideo(opts ...func(*VideoQuery)) *UserQuery {
 // Example:
 //
 //	var v []struct {
-//		Nickname string `json:"nickname,omitempty"`
+//		ProfileImage string `json:"profile_image,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.User.Query().
-//		GroupBy(user.FieldNickname).
+//		GroupBy(user.FieldProfileImage).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
 //
@@ -462,11 +462,11 @@ func (uq *UserQuery) GroupBy(field string, fields ...string) *UserGroupBy {
 // Example:
 //
 //	var v []struct {
-//		Nickname string `json:"nickname,omitempty"`
+//		ProfileImage string `json:"profile_image,omitempty"`
 //	}
 //
 //	client.User.Query().
-//		Select(user.FieldNickname).
+//		Select(user.FieldProfileImage).
 //		Scan(ctx, &v)
 //
 func (uq *UserQuery) Select(fields ...string) *UserSelect {

--- a/rest-api/ent/user_update.go
+++ b/rest-api/ent/user_update.go
@@ -32,6 +32,26 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// SetProfileImage sets the "profile_image" field.
+func (uu *UserUpdate) SetProfileImage(s string) *UserUpdate {
+	uu.mutation.SetProfileImage(s)
+	return uu
+}
+
+// SetNillableProfileImage sets the "profile_image" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableProfileImage(s *string) *UserUpdate {
+	if s != nil {
+		uu.SetProfileImage(*s)
+	}
+	return uu
+}
+
+// ClearProfileImage clears the value of the "profile_image" field.
+func (uu *UserUpdate) ClearProfileImage() *UserUpdate {
+	uu.mutation.ClearProfileImage()
+	return uu
+}
+
 // SetNickname sets the "nickname" field.
 func (uu *UserUpdate) SetNickname(s string) *UserUpdate {
 	uu.mutation.SetNickname(s)
@@ -399,6 +419,19 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			}
 		}
 	}
+	if value, ok := uu.mutation.ProfileImage(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: user.FieldProfileImage,
+		})
+	}
+	if uu.mutation.ProfileImageCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: user.FieldProfileImage,
+		})
+	}
 	if value, ok := uu.mutation.Nickname(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
@@ -754,6 +787,26 @@ type UserUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *UserMutation
+}
+
+// SetProfileImage sets the "profile_image" field.
+func (uuo *UserUpdateOne) SetProfileImage(s string) *UserUpdateOne {
+	uuo.mutation.SetProfileImage(s)
+	return uuo
+}
+
+// SetNillableProfileImage sets the "profile_image" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableProfileImage(s *string) *UserUpdateOne {
+	if s != nil {
+		uuo.SetProfileImage(*s)
+	}
+	return uuo
+}
+
+// ClearProfileImage clears the value of the "profile_image" field.
+func (uuo *UserUpdateOne) ClearProfileImage() *UserUpdateOne {
+	uuo.mutation.ClearProfileImage()
+	return uuo
 }
 
 // SetNickname sets the "nickname" field.
@@ -1146,6 +1199,19 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 				ps[i](selector)
 			}
 		}
+	}
+	if value, ok := uuo.mutation.ProfileImage(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: user.FieldProfileImage,
+		})
+	}
+	if uuo.mutation.ProfileImageCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: user.FieldProfileImage,
+		})
 	}
 	if value, ok := uuo.mutation.Nickname(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{

--- a/rest-api/go.mod
+++ b/rest-api/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/pkg/errors v0.9.1 => github.com/depromeet/errors v0.9.2

--- a/rest-api/go.sum
+++ b/rest-api/go.sum
@@ -99,6 +99,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-openapi/inflect v0.19.0 h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=
 github.com/go-openapi/inflect v0.19.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
 github.com/go-sql-driver/mysql v1.5.1-0.20200311113236-681ffa848bae h1:L6V0ANsMIMdLgXly241UXhXNFWYgXbgjHupTAAURrV0=
 github.com/go-sql-driver/mysql v1.5.1-0.20200311113236-681ffa848bae/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -232,6 +233,7 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -252,6 +254,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
@@ -292,6 +295,7 @@ github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/rest-api/go.sum
+++ b/rest-api/go.sum
@@ -99,7 +99,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-openapi/inflect v0.19.0 h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=
 github.com/go-openapi/inflect v0.19.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
 github.com/go-sql-driver/mysql v1.5.1-0.20200311113236-681ffa848bae h1:L6V0ANsMIMdLgXly241UXhXNFWYgXbgjHupTAAURrV0=
 github.com/go-sql-driver/mysql v1.5.1-0.20200311113236-681ffa848bae/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -233,7 +232,6 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -254,7 +252,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
@@ -295,7 +292,6 @@ github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/rest-api/go.sum
+++ b/rest-api/go.sum
@@ -80,6 +80,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/depromeet/errors v0.9.2 h1:iWLzTFguTeRYTUeDXj3cFvV+jq/GnkNIMRsO/rILtpo=
+github.com/depromeet/errors v0.9.2/go.mod h1:1UUhzLXT3Vvk0yvjGcSxZVbDsd/IFYH9MShusNXNIAY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -261,8 +263,6 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/rest-api/infra/http/middleware.go
+++ b/rest-api/infra/http/middleware.go
@@ -3,7 +3,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/depromeet/everybody-backend/rest-api/ent"
+	"github.com/depromeet/everybody-backend/rest-api/service"
 	"github.com/gofiber/fiber/v2"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -19,16 +19,18 @@ type ErrorResponse struct {
 // errorHandle 은 최종적으로 리턴된 error들에 대해 적절한 응답을 생성하고
 // 예상치 못한 에러의 경우 500 에러로 응답합니다.
 func errorHandle(ctx *fiber.Ctx, err error) error {
-	log.Error(err)
-	notFoundErr := &ent.NotFoundError{}
-	unmarshalTypeErr := &json.UnmarshalTypeError{}
-	if errors.As(err, &notFoundErr) {
+	rootErr := errors.GetRootStackError(err)
+	log.Errorf("%+v", rootErr)
+
+	notFoundErr := new(service.NotFoundError)
+	unmarshalTypeErr := new(json.UnmarshalTypeError)
+
+	if errors.As(err, notFoundErr) {
 		return ctx.Status(404).JSON(newErrorResponse("리소스를 찾을 수 없습니다.", reflect.TypeOf(err).Name()))
 	} else if errors.As(err, &unmarshalTypeErr) {
 		e := errors.Cause(err).(*json.UnmarshalTypeError) // .Cause()는 .Cause()를 구현하지 않은 에러를 error로 리턴합니다.
 		return ctx.Status(400).JSON(newErrorResponse(fmt.Sprintf("%s에 대한 잘못된 타입의 값입니다. %s 타입을 이용해주세요.", e.Field, e.Type.Name()), reflect.TypeOf(e).Name()))
 	} else {
-		log.Errorf("%+v", err)
 		return ctx.Status(500).JSON(newErrorResponse("알 수 없는 에러가 발생했습니다. 에브리바디에 문의해주세요.", "internalError"))
 	}
 }

--- a/rest-api/repository/album.go
+++ b/rest-api/repository/album.go
@@ -34,6 +34,7 @@ func (r *albumRepository) Create(album *ent.Album) (*ent.Album, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// TODO: 이 부분에서 근데 EagerLoading 안 잡아주면 에러날 것 같은데
 
 	return newAlbum, nil
 }
@@ -42,6 +43,13 @@ func (r *albumRepository) GetAllByUserID(userID int) ([]*ent.Album, error) {
 	albums, err := r.db.Album.Query().
 		Where(album.HasUserWith(user.ID(userID))).
 		WithUser().
+		WithPicture(func(query *ent.PictureQuery) {
+			query.WithAlbum(func(query *ent.AlbumQuery) {
+				query.Select("id")
+			}).
+				WithUser().
+				Order(ent.Asc("taken_at", "created_at"))
+		}).
 		All(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -54,6 +62,13 @@ func (r *albumRepository) Get(albumID int) (*ent.Album, error) {
 	albumData, err := r.db.Album.Query().
 		Where(album.ID(albumID)).
 		WithUser().
+		WithPicture(func(query *ent.PictureQuery) {
+			query.WithAlbum(func(query *ent.AlbumQuery) {
+				query.Select("id")
+			}).
+				WithUser().
+				Order(ent.Asc("taken_at", "created_at"))
+		}).
 		Only(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/rest-api/repository/picture.go
+++ b/rest-api/repository/picture.go
@@ -34,6 +34,7 @@ func (r *pictureRepository) Save(picture *ent.Picture) (*ent.Picture, error) {
 		SetAlbum(picture.Edges.Album).
 		SetBodyPart(picture.BodyPart).
 		SetKey(picture.Key).
+		SetTakenAt(picture.TakenAt).
 		Save(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -59,6 +60,7 @@ func (r *pictureRepository) GetAllByUserID(userID int) ([]*ent.Picture, error) {
 		Where(picture.HasUserWith(user.ID(userID))).
 		WithUser().
 		WithAlbum().
+		Order(ent.Asc("taken_at")).
 		All(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -73,6 +75,7 @@ func (r *pictureRepository) GetAllByAlbumID(albumID int) ([]*ent.Picture, error)
 		Where(picture.HasAlbumWith(album.ID(albumID))).
 		WithUser().
 		WithAlbum().
+		Order(ent.Asc("taken_at")).
 		All(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -100,6 +103,7 @@ func (r *pictureRepository) FindByAlbumIDAndBodyPart(albumID int, bodyPart strin
 		Where(picture.And(picture.HasAlbumWith(album.ID(albumID)), picture.BodyPart(bodyPart))).
 		WithUser().
 		WithAlbum().
+		Order(ent.Asc("taken_at")).
 		All(context.Background())
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/rest-api/repository/user.go
+++ b/rest-api/repository/user.go
@@ -28,6 +28,7 @@ func (repo *userRepository) Create(user *ent.User) (*ent.User, error) {
 	result, err := repo.db.User.Create().
 		SetNickname(user.Nickname).
 		SetMotto(user.Motto).
+		SetProfileImage(user.ProfileImage).
 		SetKind(user.Kind).
 		SetNillableHeight(user.Height).
 		SetNillableWeight(user.Weight).

--- a/rest-api/service/album.go
+++ b/rest-api/service/album.go
@@ -50,10 +50,6 @@ func (s *albumService) GetAllAlbums(userID int) (dto.AlbumsDto, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	if len(albums) == 0 {
-		return nil, errors.WithStack(errors.New("해당하는 리소스를 찾지 못했습니다."))
-	}
-
 	// album들의 각각의 사진들도 조회(사진이 없을 수도 있음)
 	allPictures, err := s.pictureRepo.GetAllByUserID(userID)
 	if err != nil {

--- a/rest-api/service/album.go
+++ b/rest-api/service/album.go
@@ -50,28 +50,12 @@ func (s *albumService) GetAllAlbums(userID int) (dto.AlbumsDto, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	// album들의 각각의 사진들도 조회(사진이 없을 수도 있음)
-	allPictures, err := s.pictureRepo.GetAllByUserID(userID)
-	if err != nil {
-		return nil, err
+	if len(albums) == 0 {
+		return nil, errors.WithStack(errors.New("해당하는 리소스를 찾지 못했습니다."))
 	}
 
-	albumsWithPictures := make([]*ent.Album, 0)
-	for _, album := range albums {
-		pictures := make([]*ent.Picture, 0)
-		// 사용자의 전체 사진을 각 앨범에 맞게 조립...
-		for _, picture := range allPictures {
-			if album.ID == picture.Edges.Album.ID {
-				pictures = append(pictures, picture)
-			}
-		}
-
-		album.Edges.Picture = pictures
-		albumsWithPictures = append(albumsWithPictures, album)
-	}
-
-	log.Info("전체 앨범과 그 앨범들의 사진들을 조회 완료")
-	return dto.AlbumsToDto(albumsWithPictures), nil
+	log.Info("전체 앨범 조회 완료 (그 속 사진들은 Eager loading으로 조회)")
+	return dto.AlbumsToDto(albums), nil
 }
 
 // GetAlbum은 alubm 정보와 album의 사진 정보들도 조회

--- a/rest-api/service/error.go
+++ b/rest-api/service/error.go
@@ -1,0 +1,7 @@
+package service
+
+type NotFoundError error
+
+//func IsNotFound(err error) bool {
+//	return ent.IsNotFound(err)
+//}

--- a/rest-api/service/picture.go
+++ b/rest-api/service/picture.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/depromeet/everybody-backend/rest-api/util"
 	"strconv"
 
 	"github.com/depromeet/everybody-backend/rest-api/dto"
@@ -41,6 +42,11 @@ func (s *pictureService) SavePicture(userID int, pictureReq *dto.CreatePictureRe
 		return nil, errors.WithStack(errors.New("요청한 유저는 리소스에 접근할 권한이 없습니다."))
 	}
 
+	takenAt, err := util.ConvertIntToTime(pictureReq.TakenAtYear, pictureReq.TakenAtMonth, pictureReq.TakenAtMonth)
+	if err != nil {
+		return nil, errors.Wrapf(err, "잘못된 날짜 형식입니다. (%4d, %2d, %2d", pictureReq.TakenAtYear, pictureReq.TakenAtMonth, pictureReq.TakenAtMonth)
+	}
+
 	picture := &ent.Picture{
 		BodyPart: pictureReq.BodyPart,
 		Edges: ent.PictureEdges{
@@ -48,7 +54,7 @@ func (s *pictureService) SavePicture(userID int, pictureReq *dto.CreatePictureRe
 			Album: &ent.Album{ID: pictureReq.AlbumID},
 		},
 		Key:     pictureReq.Key,
-		TakenAt: pictureReq.TakenAt,
+		TakenAt: takenAt,
 	}
 
 	p, err := s.pictureRepo.Save(picture)

--- a/rest-api/service/picture.go
+++ b/rest-api/service/picture.go
@@ -47,7 +47,8 @@ func (s *pictureService) SavePicture(userID int, pictureReq *dto.CreatePictureRe
 			User:  &ent.User{ID: userID},
 			Album: &ent.Album{ID: pictureReq.AlbumID},
 		},
-		Key: pictureReq.Key,
+		Key:     pictureReq.Key,
+		TakenAt: pictureReq.TakenAt,
 	}
 
 	p, err := s.pictureRepo.Save(picture)
@@ -93,11 +94,6 @@ func (s *pictureService) GetAllPictures(userID int, pictureReq *dto.GetPictureRe
 			return nil, errors.WithStack(err)
 		}
 
-		// Notfounderr로 wrapping?
-		if len(pictures) == 0 {
-			return nil, errors.WithStack(errors.New("해당하는 리소스를 찾지 못했습니다."))
-		}
-
 		log.Info("사용자의 모든 사진들을 조회 완료")
 		return dto.PicturesToDto(pictures), nil
 	}
@@ -115,14 +111,11 @@ func (s *pictureService) GetAllPictures(userID int, pictureReq *dto.GetPictureRe
 			return nil, errors.WithStack(err)
 		}
 
-		// Notfounderr로 wrapping?
-		if len(pictures) == 0 {
-			return nil, errors.WithStack(errors.New("해당하는 리소스를 찾지 못했습니다."))
-		}
-
-		// forbiddenerr로 wrapping?
-		if userID != pictures[0].Edges.User.ID {
-			return nil, errors.WithStack(errors.New("요청한 유저는 리소스에 접근할 권한이 없습니다."))
+		if len(pictures) > 0 {
+			// forbiddenerr로 wrapping?
+			if userID != pictures[0].Edges.User.ID {
+				return nil, errors.WithStack(errors.New("요청한 유저는 리소스에 접근할 권한이 없습니다."))
+			}
 		}
 
 		log.Info("특정 앨범과 신체 부위에 맞는 사진들 조회")
@@ -134,14 +127,11 @@ func (s *pictureService) GetAllPictures(userID int, pictureReq *dto.GetPictureRe
 		return nil, errors.WithStack(err)
 	}
 
-	// Notfounderr로 wrapping?
-	if len(pictures) == 0 {
-		return nil, errors.WithStack(errors.New("해당하는 리소스를 찾지 못했습니다."))
-	}
-
-	// forbiddenerr로 wrapping?
-	if userID != pictures[0].Edges.User.ID {
-		return nil, errors.WithStack(errors.New("요청한 유저는 리소스에 접근할 권한이 없습니다."))
+	if len(pictures) > 0 {
+		// forbiddenerr로 wrapping?
+		if userID != pictures[0].Edges.User.ID {
+			return nil, errors.WithStack(errors.New("요청한 유저는 리소스에 접근할 권한이 없습니다."))
+		}
 	}
 
 	log.Info("특정 앨범의 사진들 조회")

--- a/rest-api/service/picture_test.go
+++ b/rest-api/service/picture_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/depromeet/everybody-backend/rest-api/dto"
 	"github.com/depromeet/everybody-backend/rest-api/ent"
@@ -32,7 +33,15 @@ func TestPictureServiceSave(t *testing.T) {
 
 		albumRepo.On("Get", mock.AnythingOfType("int")).Return(expectedAlbum, nil)
 		pictureRepo.On("Save", mock.AnythingOfType("*ent.Picture")).Return(expectedPicture, nil)
-		picture, err := pictureSvc.SavePicture(0, &dto.CreatePictureRequest{AlbumID: 0})
+		picture, err := pictureSvc.SavePicture(0, &dto.CreatePictureRequest{
+			ID:           0,
+			AlbumID:      0,
+			BodyPart:     "",
+			Key:          "",
+			TakenAtYear:  2021,
+			TakenAtMonth: 11,
+			TakenAtDay:   5,
+		})
 		assert.NoError(t, err)
 		assert.Equal(t, dto.PictureToDto(expectedPicture), picture)
 	})
@@ -44,6 +53,8 @@ func TestPictureServiceGetAll(t *testing.T) {
 	var expectedPictures []*ent.Picture
 	expectedPictures = append(expectedPictures, &ent.Picture{
 		BodyPart: "upper",
+		TakenAt:  time.Now(),
+
 		Edges: ent.PictureEdges{
 			User:  &ent.User{ID: 0},
 			Album: &ent.Album{ID: 0},

--- a/rest-api/service/user.go
+++ b/rest-api/service/user.go
@@ -23,6 +23,10 @@ var (
 	randomNicknameNouns = []string{
 		"고양이", "멍멍이", "댕댕이", "냥이", "기요밍", "튼튼이", "헬린이", "뽀로로", "뿌앙이",
 	}
+	// randomProfileImageKey 는 public drive s3에 미리 업로드 해둔 샘플이다.
+	randomProfileImageKey = []string{
+		"beam-1.png", "beam-2.png", "beam-3.png", "beam-4.png", "beam-5.png", "beam-6.png",
+	}
 	defaultMotto = "천천히 그리고 꾸준히!"
 )
 
@@ -56,11 +60,12 @@ type userService struct {
 // TODO: 트랜잭션 롤백이 안됨. 유저를 만들고 다른 것들을 만들다가 종료되면..?
 func (s *userService) SignUp(body *dto.SignUpRequest) (*dto.UserDto, error) {
 	user, err := s.userRepo.Create(&ent.User{
-		Nickname: s.generateUniqueNickname(),
-		Motto:    defaultMotto,
-		Height:   body.Height,
-		Weight:   body.Weight,
-		Kind:     entUser.Kind(body.Kind),
+		Nickname:     s.generateUniqueNickname(),
+		Motto:        defaultMotto,
+		Height:       body.Height,
+		Weight:       body.Weight,
+		ProfileImage: s.getRandomProfileImageKey(),
+		Kind:         entUser.Kind(body.Kind),
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -114,6 +119,9 @@ func (s *userService) UpdateUser(id int, body *dto.UpdateUserRequest) (*dto.User
 	return dto.UserToDto(user), err
 }
 
+func (s *userService) getRandomProfileImageKey() string {
+	return randomProfileImageKey[rand.Intn(len(randomProfileImageKey))]
+}
 func (s *userService) generateUniqueNickname() string {
 	suffix := 0
 	adj := randomNicknameAdjectives[rand.Intn(len(randomNicknameAdjectives))]

--- a/rest-api/service/user_test.go
+++ b/rest-api/service/user_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/depromeet/everybody-backend/rest-api/dto"
 	"github.com/depromeet/everybody-backend/rest-api/ent"
+	"github.com/depromeet/everybody-backend/rest-api/ent/user"
 	"github.com/depromeet/everybody-backend/rest-api/mocks"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -111,7 +112,7 @@ func TestUserService_Update(t *testing.T) {
 
 		// 수정되지 말아야하는 필드
 		assert.Equal(t, result.CreatedAt, original.CreatedAt)
-		assert.Equal(t, result.Kind, "SIMPLE")
+		assert.Equal(t, result.Kind, user.KindSIMPLE)
 	})
 
 	t.Run("실패) 존재하지 않는 유저에 대한 수정", func(t *testing.T) {

--- a/rest-api/util/util.go
+++ b/rest-api/util/util.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"strconv"
+	"time"
 )
 
 func GetRequestUserID(ctx *fiber.Ctx) (int, error) {
@@ -15,4 +17,12 @@ func GetParams(ctx *fiber.Ctx, params string) string {
 
 func GetQueryParams(ctx *fiber.Ctx, params string) string {
 	return ctx.Query(params, "")
+}
+
+func ConvertStrToTime(year, month, day int) (time.Time, error) {
+	return time.Parse(time.RFC3339, fmt.Sprintf("%04d-%02d-%02dT12:00:00+09:00", year, month, day))
+}
+
+func ConvertTimeToStr(t time.Time) (year, month, day int) {
+	return t.Year(), int(t.Month()), t.Day()
 }

--- a/rest-api/util/util.go
+++ b/rest-api/util/util.go
@@ -19,7 +19,7 @@ func GetQueryParams(ctx *fiber.Ctx, params string) string {
 	return ctx.Query(params, "")
 }
 
-func ConvertStrToTime(year, month, day int) (time.Time, error) {
+func ConvertIntToTime(year, month, day int) (time.Time, error) {
 	return time.Parse(time.RFC3339, fmt.Sprintf("%04d-%02d-%02dT12:00:00+09:00", year, month, day))
 }
 

--- a/rest-api/util/util_test.go
+++ b/rest-api/util/util_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_ConvertStrToTime(t *testing.T) {
+	// RFC3339 포맷 이용
+	expected, err := time.Parse(time.RFC3339, "2021-08-17T12:00:00+09:00")
+	assert.NoError(t, err)
+	converted, err := ConvertStrToTime(2021, 8, 17)
+	assert.Equal(t, expected, converted)
+
+	_, err = ConvertStrToTime(0, 0, 0)
+	assert.Error(t, err)
+}
+
+func Test_ConvertTimeToStr(t *testing.T) {
+	// RFC3339 포맷 이용
+	expected, err := time.Parse(time.RFC3339, "2021-08-17T12:00:00+09:00")
+	assert.NoError(t, err)
+	year, month, day := ConvertTimeToStr(expected)
+	assert.Equal(t, 2021, year)
+	assert.Equal(t, 8, month)
+	assert.Equal(t, 17, day)
+}

--- a/rest-api/util/util_test.go
+++ b/rest-api/util/util_test.go
@@ -6,14 +6,14 @@ import (
 	"time"
 )
 
-func Test_ConvertStrToTime(t *testing.T) {
+func Test_ConvertIntToTime(t *testing.T) {
 	// RFC3339 포맷 이용
 	expected, err := time.Parse(time.RFC3339, "2021-08-17T12:00:00+09:00")
 	assert.NoError(t, err)
-	converted, err := ConvertStrToTime(2021, 8, 17)
+	converted, err := ConvertIntToTime(2021, 8, 17)
 	assert.Equal(t, expected, converted)
 
-	_, err = ConvertStrToTime(0, 0, 0)
+	_, err = ConvertIntToTime(0, 0, 0)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
현재 기획상 사용자는 앨범을 몇 개 안 만들 것이고, 사진은 어차피 다 조회되어야하므로 앨범 조회 시 속한 사진 정보도 모두 제공.

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
##### ent의 eager loading(fetch join)을 통한 앨범 조회 시 사진도 함께 조회하기
```go
albums, err := r.db.Album.Query().
	Where(album.HasUserWith(user.ID(userID))).
	WithUser().
	WithPicture(func(query *ent.PictureQuery) {
		query.WithAlbum(func(query *ent.AlbumQuery) {
			query.Select("id")
		}).
			WithUser().
			Order(ent.Asc("taken_at", "created_at"))
	}).
	All(context.Background())
```

위와 같이 With나 query를 통해 미리 조회해올 수 있습니다! service에서 album 조회 후 다시 picture repository를 통해 조회하는 로직을 구현하지 않아도 되게 돼죠!

사진 정렬은 먼저 찍은(`taken_at ASC`) 사진 순. 그게 같으면 업로드 한 시간 순(`created_at ASC`)

* 클라이언트랑 논의한 결과 요청 바디에서 사용자에게 사진을 언제 찍었는지 전달 받는 필드는 `time.Time` 말고 년도, 월, 일 따로 받는 걸로 결정해서 그렇게 변경했습니다. 클라이언트 측에서 그게 편하다고 하네요.
  년도, 월, 일을 받아서 서버 측에서 `time.TIme` 으로 변환합니다. `util` 의 테스트 코드쪽 보시면 이해가 편하실 것 같습니다.

* (추가적으로 가입할 때 랜덤하게 프로필 이미지를 선정하는 기능 요청이 있어서 그 부분도 추가해놨습니다. private한 앨범 쪽 S3 Bucket과 달리 이런 저런 Public한 정적 데이터들을 위해 `everybody-public-drive`라는  버킷을 두었고 여기에 샘플 프로필 이미지들을 업로드 해두었습니다. (Optional)**config에 약간의 수정 필요**)
#### 📸 ScreenShot
<!-- Optional -->

##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #
