### PR TITLE
nginx 바디 사이즈 제한 완화

### DIFF
--- a/.platform/nginx/conf.d/custom.conf
+++ b/.platform/nginx/conf.d/custom.conf
@@ -1,0 +1,3 @@
+# Amazon Linux 2의 nginx 설정 방법
+# 참고: https://stackoverflow.com/a/62845853/9471220
+client_max_body_size 10M;


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
사진이 1MB이상인 걸 업로드하면 413 Request Entity Too Large 에러가 나서 nginx 바디 사이즈를 10MB로 늘려놨습니다.

#### 📌 디버깅
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
```bash
$ tail -n /var/log/nginx/error.log
...
2021/11/13 11:17:43 [error] 24023#24023: *71 client intended to send too large body: 1063458 bytes, client: 172.31.16.36, server: , request: "POST /pictures HTTP/1.1", host: "api.noonbody.me"
...
```
어디서 요청을 거부하는지를 찾기 위해 로그를 뒤져보니 EB instance 속 Nginx 단에서 요청을 거부하고 있었다.

eb 관련 설정에서 nginx 쪽을 커스터마이징해서 해결.
참고: https://stackoverflow.com/a/62845853/9471220

#### 📸 ScreenShot
<!-- Optional -->

##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #
