### PR TITLE
앨범 조회할 때 대표 썸네일 추가 및 신체부위 key로 하는 dto 보완

### DIFF
--- a/rest-api/dto/album.go
+++ b/rest-api/dto/album.go
@@ -43,16 +43,13 @@ func AlbumToDto(srcAlbum *ent.Album) *AlbumDto {
 	picturesDto := PicturesToDto(srcAlbum.Edges.Picture)
 	picturesMap := make(map[string]PicturesDto)
 
-	for _, pictureDto := range picturesDto {
-		picturesMap[pictureDto.BodyPart] = append(picturesMap[pictureDto.BodyPart], pictureDto)
+	// 각 신체부위 key에 대한 초기화
+	for _, bodyPart := range bodyPartKey {
+		picturesMap[bodyPart] = make(PicturesDto, 0)
 	}
 
-	emptyPicturesDto := make(PicturesDto, 0)
-	for _, bodyPart := range bodyPartKey {
-		// bodyPart가 없는 사진들 빈 리스트로 초기화
-		if _, ok := picturesMap[bodyPart]; !ok {
-			picturesMap[bodyPart] = emptyPicturesDto
-		}
+	for _, pictureDto := range picturesDto {
+		picturesMap[pictureDto.BodyPart] = append(picturesMap[pictureDto.BodyPart], pictureDto)
 	}
 
 	// 각 앨범의 대표 썸네일(가장 최신 사진으로)

--- a/rest-api/dto/album.go
+++ b/rest-api/dto/album.go
@@ -12,29 +12,21 @@ type AlbumRequest struct {
 	Name string `json:"name"`
 }
 
-// PictureDto는 AlbumID 필드도 가지고 있음
-// AlbumDto 할 때 picture에도 album_id를 중복으로
-// 가지는 것이 불필요해서 AlbumPicture 구조체를 선언하려고
-// 생각하다가 우선은 PictureDto로 하는 걸로...
-// type AlbumPicture struct {
-// 	PictureID int       `json:"picture_id"`
-// 	BodyPart  string    `json:"body_part"`
-// 	CreatedAt time.Time `json:"created_at"`
-// 	Key  string    `json:"location"`
-// }
-
 type AlbumsDto []*AlbumDto
 type AlbumDto struct {
-	ID        int       `json:"id"`
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"created_at"`
+	ID           int       `json:"id"`
+	Name         string    `json:"name"`
+	ThumbnailURL *string   `json:"thumbnail_url"`
+	CreatedAt    time.Time `json:"created_at"`
+	Description  string    `json:"description"`
 	// 클라이언트측에서는 부위별로 분류된 사진 리스트가 필요함.
 	// TODO: 특정 부위의 사진이 한 장도 없을 때 클라이언트 측에서 맵을 사용하면서 undefined 나 no key(?) 같은 에러를 겪지 않게 하려면
 	// 서버측에서 부위에 대한 Enum을 정의해서 각 부위별로 사진이 하나도 없는 부위는 빈 리스트를 전달해줘야할 것 같아요.
-	Pictures    map[string]PicturesDto `json:"pictures"`
-	Description string                 `json:"description"`
+	Pictures map[string]PicturesDto `json:"pictures"`
 	// Videos    VideosDto   `json:"videos"`
 }
+
+var bodyPartKey = []string{"whole", "upper", "lower"}
 
 func AlbumsToDto(srcAlbums []*ent.Album) AlbumsDto {
 	albumsDto := make(AlbumsDto, 0)
@@ -50,19 +42,35 @@ func AlbumsToDto(srcAlbums []*ent.Album) AlbumsDto {
 func AlbumToDto(srcAlbum *ent.Album) *AlbumDto {
 	picturesDto := PicturesToDto(srcAlbum.Edges.Picture)
 	picturesMap := make(map[string]PicturesDto)
+
 	for _, pictureDto := range picturesDto {
 		picturesMap[pictureDto.BodyPart] = append(picturesMap[pictureDto.BodyPart], pictureDto)
 	}
+
+	emptyPicturesDto := make(PicturesDto, 0)
+	for _, bodyPart := range bodyPartKey {
+		// bodyPart가 없는 사진들 빈 리스트로 초기화
+		if _, ok := picturesMap[bodyPart]; !ok {
+			picturesMap[bodyPart] = emptyPicturesDto
+		}
+	}
+
+	// 각 앨범의 대표 썸네일(가장 최신 사진으로)
+	var thumbnail *string
+	if len(picturesDto) > 0 {
+		thumbnail = &picturesDto[len(picturesDto)-1].ThumbnailURL
+	}
+
 	duration := time.Now().Sub(srcAlbum.CreatedAt)
 	description := fmt.Sprintf("%d일 간의 기록", int(duration.Hours())/24+1)
 
 	return &AlbumDto{
-		ID:          srcAlbum.ID,
-		Name:        srcAlbum.Name,
-		Description: description,
-		CreatedAt:   srcAlbum.CreatedAt,
-		Pictures:    picturesMap,
-		// Videos:
+		ID:           srcAlbum.ID,
+		Name:         srcAlbum.Name,
+		ThumbnailURL: thumbnail,
+		Description:  description,
+		CreatedAt:    srcAlbum.CreatedAt,
+		Pictures:     picturesMap,
 	}
 }
 

--- a/rest-api/service/picture.go
+++ b/rest-api/service/picture.go
@@ -1,12 +1,12 @@
 package service
 
 import (
-	"github.com/depromeet/everybody-backend/rest-api/util"
 	"strconv"
 
 	"github.com/depromeet/everybody-backend/rest-api/dto"
 	"github.com/depromeet/everybody-backend/rest-api/ent"
 	"github.com/depromeet/everybody-backend/rest-api/repository"
+	"github.com/depromeet/everybody-backend/rest-api/util"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -43,7 +43,7 @@ func (s *pictureService) SavePicture(userID int, pictureReq *dto.CreatePictureRe
 
 	// 요청한 유저와 앨범의 소유주와 다르다면 그 앨범에 사진이 저장이 되면 안됨
 	if userID != album.Edges.User.ID {
-		return nil, errors.Wrap(ForbiddenError, "본인의 사진만을 조회할 수 있습니다.")
+		return nil, errors.Wrap(ForbiddenError, "본인의 앨범에만 사진을 업로드할 수 있습니다.")
 	}
 
 	takenAt, err := util.ConvertIntToTime(pictureReq.TakenAtYear, pictureReq.TakenAtMonth, pictureReq.TakenAtMonth)


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
- 앨범 조회할 때 대표 썸네일 추가했고 신체부위 각 key마다의 값을 응답으로 리턴

#### 📌 변경 사항
#### 📸 ScreenShot
<!-- Optional -->
![image](https://user-images.githubusercontent.com/44899448/141643676-1dc693a9-5acb-4b41-8413-9af81abe9a90.png)

위의 스샷처럼 lower, upper 에는 사진들이 없어도 빈 리스트를 응답으로 줬고 thumbnail_url도 최신 걸로다가 하나 던져줬습니다
##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #
