### PR TITLE
feat: 시간 unmarshal 에러를 500이 아닌 400으로 처리

### DIFF
--- a/rest-api/er/error.go
+++ b/rest-api/er/error.go
@@ -1,0 +1,10 @@
+package er
+
+// WrongTimeFormatErr 는 잘못된 시간을 나타내는
+type WrongTimeFormatErr struct {
+	Err error
+}
+
+func (e *WrongTimeFormatErr) Error() string {
+	return "잘못된 시간 포맷입니다: " + e.Err.Error()
+}

--- a/rest-api/error/error.go
+++ b/rest-api/error/error.go
@@ -1,1 +1,0 @@
-package error

--- a/rest-api/infra/http/middleware.go
+++ b/rest-api/infra/http/middleware.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/depromeet/everybody-backend/rest-api/ent"
+	"github.com/depromeet/everybody-backend/rest-api/er"
 	"github.com/depromeet/everybody-backend/rest-api/infra/http/handler"
 	"github.com/depromeet/everybody-backend/rest-api/service"
 	"github.com/depromeet/everybody-backend/rest-api/util"
@@ -41,6 +42,12 @@ func errorHandle(ctx *fiber.Ctx, err error) error {
 	} else if errors.Is(err, service.ForbiddenError) {
 		return ctx.Status(403).JSON(newErrorResponse(util.GetErrorMessageForClient(err.Error()), "forbidden_error"))
 	} else {
+		cause := errors.Cause(err)
+		wrongTimeFormatErr := new(er.WrongTimeFormatErr)
+		if errors.As(cause, &wrongTimeFormatErr) {
+			return ctx.Status(400).JSON(newErrorResponse(util.GetErrorMessageForClient(err.Error()), "wrong_time_format_error"))
+		}
+
 		return ctx.Status(500).JSON(newErrorResponse("알 수 없는 에러가 발생했습니다. 에브리바디에 문의해주세요.", "internal_error"))
 	}
 }

--- a/rest-api/util/util.go
+++ b/rest-api/util/util.go
@@ -3,8 +3,9 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/depromeet/everybody-backend/rest-api/er"
 	"github.com/gofiber/fiber/v2"
-	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"
@@ -19,13 +20,16 @@ var (
 )
 
 // ct에 저장
+// util 함수들은 굳이 stack 정보를 제공할 필요까지는 없을 듯
+// util을 호출한 쪽의 스택 정보 정도만 있으면 됨.
 func (ct *CustomTime) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
-		return errors.WithStack(err)
+		log.Error(err)
+		return &er.WrongTimeFormatErr{Err: err}
 	}
 	if t, err := time.Parse("2006-01-02 15:04:05", s); err != nil {
-		return errors.WithStack(err)
+		return &er.WrongTimeFormatErr{Err: err}
 	} else {
 		// 전달받은 건 한국시인데 해석할 때에는 같은 절대 시간값으로 UTC로 해석하기 때문에 9시간을 더해준다.
 		t.In(location)

--- a/rest-api/util/util_test.go
+++ b/rest-api/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"github.com/depromeet/everybody-backend/rest-api/er"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -27,6 +28,38 @@ func Test_ConvertTimeToStr(t *testing.T) {
 	assert.Equal(t, 17, day)
 	assert.Equal(t, 12, hour)
 	assert.Equal(t, 03, min)
+}
+
+func TestCustomTime_UnmarshalJSON(t *testing.T) {
+	// ct에 저장
+	t.Run("성공", func(t *testing.T) {
+		tmp := &CustomTime{}
+		err := tmp.UnmarshalJSON([]byte("\"2021-12-02 20:30:00\""))
+		assert.NoError(t, err)
+	})
+
+	t.Run("실패) 빈 값", func(t *testing.T) {
+		tmp := &CustomTime{}
+		target := &er.WrongTimeFormatErr{}
+		err := tmp.UnmarshalJSON([]byte(""))
+		assert.ErrorAs(t, err, &target)
+		wrongTimeFormatErr := err.(*er.WrongTimeFormatErr)
+		// 참고: Error 인터페이스는 %s 시에String()메소드가 아니라 Error() 메소드를 이용하네
+		t.Log(wrongTimeFormatErr)
+		t.Logf("%+v\n", wrongTimeFormatErr)
+	})
+
+	t.Run("실패) 이상한 값", func(t *testing.T) {
+		tmp := &CustomTime{}
+		target := &er.WrongTimeFormatErr{}
+		err := tmp.UnmarshalJSON([]byte("\"hello, world\""))
+		assert.ErrorAs(t, err, &target)
+		wrongTimeFormatErr := err.(*er.WrongTimeFormatErr)
+		// 참고: Error 인터페이스는 %s 시에String()메소드가 아니라 Error() 메소드를 이용하네
+		t.Log(wrongTimeFormatErr)
+		t.Logf("%+v\n", err)
+	})
+
 }
 
 //func Test_ConvertTimeToStr(t *testing.T) {


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
시간 unmarshal하다 에러나면 500이 아닌 400으로 응답
#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

* 기존에는 시간 unmarshal하다 에러가 나면 500 에러로 응답했기 때문에 클라이언트가 그 원인을 찾기 힘들었다.
  => 이제는 400 응답과 함께 그 이유를 전달해주기 때문에 클라이언트가 좀 더 에러를 처리하기 편할 것이다.
  어떤 필드 때문에 오류가 난 건지(이번에 이슈가 된 건 사진 찍은 시기인 `taken_at` 필드)도 알 수 있으면 좋을텐데, fiber 측의 BodyParser를 이용하는 한은 그렇게까지 세세한 에러 메시지 제공은 힘들 것 같음.
#### 📸 ScreenShot
<!-- Optional -->
![image](https://user-images.githubusercontent.com/33250725/145413767-137c265c-211f-439a-beab-3d9822a3c6bb.png)

(한글 깨진 건 제 컴퓨터 환경 상에서만 깨진겁니다.)
##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #
