### PR TITLE
iOS 푸시 지원, 알림 설정 시 금일 알림 받을 지에 대한 로직 수정

### DIFF
--- a/rest-api/adapter/push/fcm.go
+++ b/rest-api/adapter/push/fcm.go
@@ -48,18 +48,22 @@ func (a *firebasePushAdapter) Send(title, content string, deviceInfo *ent.Device
 	registrationToken := deviceInfo.PushToken
 
 	var response string
-	if deviceInfo.DeviceOs == device.DeviceOsANDROID {
+	fmt.Println(deviceInfo.DeviceToken)
+	fmt.Println(device.DeviceOs(deviceInfo.DeviceToken))
+	fmt.Println(device.DeviceOs(deviceInfo.DeviceToken) == device.DeviceOsANDROID)
+
+	switch deviceInfo.DeviceOs {
+	case device.DeviceOsANDROID:
+		fallthrough
+	case device.DeviceOsIOS:
 		// See documentation on defining a message payload.
-		message := newAndroidMessage(registrationToken, title, content)
+		message := newMessage(registrationToken, title, content)
 		// Send a message to the device corresponding to the provided
 		// registration token.
 		response, err = client.Send(ctx, message)
 
-	} else {
-		return errors.New("아직 지원되지 않는 OS. ANDROID만 지원 중.")
-	}
-	if err != nil {
-		return errors.WithStack(err)
+	default:
+		return errors.New("아직 지원되지 않는 OS. iOS와 ANDROID만 지원 중.")
 	}
 
 	// Response is a message ID string.
@@ -69,15 +73,11 @@ func (a *firebasePushAdapter) Send(title, content string, deviceInfo *ent.Device
 
 }
 
-func newAndroidMessage(token, title, content string) *messaging.Message {
+func newMessage(token, title, content string) *messaging.Message {
 	message := &messaging.Message{
-		Android: &messaging.AndroidConfig{
-			Notification: &messaging.AndroidNotification{
-				Title: title,
-				Body:  content,
-				Icon:  "stock_ticker_update",
-				Color: "#7448FF",
-			},
+		Notification: &messaging.Notification{
+			Title: title,
+			Body:  content,
 		},
 		Token: token,
 	}

--- a/rest-api/repository/notification.go
+++ b/rest-api/repository/notification.go
@@ -90,7 +90,7 @@ func (repo *notificationRepository) FindByUser(userID int) (*ent.NotificationCon
 }
 
 func (repo *notificationRepository) Update(id int, config *ent.NotificationConfig) (*ent.NotificationConfig, error) {
-	return repo.db.NotificationConfig.UpdateOneID(id).
+	builder := repo.db.NotificationConfig.UpdateOneID(id).
 		SetUser(config.Edges.User).
 		SetMonday(config.Monday).
 		SetTuesday(config.Tuesday).
@@ -101,9 +101,18 @@ func (repo *notificationRepository) Update(id int, config *ent.NotificationConfi
 		SetSunday(config.Sunday).
 		SetPreferredTimeHour(config.PreferredTimeHour).
 		SetPreferredTimeMinute(config.PreferredTimeMinute).
-		SetNillableLastNotifiedAt(config.LastNotifiedAt).
-		SetIsActivated(config.IsActivated).
-		Save(context.Background())
+		SetIsActivated(config.IsActivated)
+	if config.LastNotifiedAt == nil {
+		builder = builder.ClearLastNotifiedAt()
+	} else {
+		builder = builder.SetLastNotifiedAt(*config.LastNotifiedAt)
+	}
+	cfg, err := builder.Save(context.Background())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return cfg, nil
 }
 
 func (repo *notificationRepository) UpdateLastNotifiedAt(id int, lastNotifiedAt time.Time) (*ent.NotificationConfig, error) {


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
iOS 푸시 지원, 알림 설정 시 금일 알림 받을 지에 대한 로직 수정

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
* 기존에는 iOS는 고려를 안해서 iOS에 알림 보내는 로직을 빼놨었는데, iOS도 추가했습니다. (실제로 동작하는지는 iOS 클라 개발자님들이랑 맞춰봐야해요.)
* 기존에는 알림 설정 시 당일에 알림이 추가적으로 발생되는 로직이 미흡했는데 이 부분 개선함.
  * 기존) 당일에 이미 알림을 받았고, 오후 6시에 알림을 받도록 오후 4시에 설정을 해도 이미 당일에 알림을 받아서 오후 6시에 알림을 받지 못함
  * 개선) 당일에 이미 알림을 받았고, 오후 6시에 알림을 받도록 오후 4시에 설정을 하면 당일 오후 6시에 다시 알림을 받을 수 있음.
  * 기존) 당일에 알림을 안 받은 상태에 오후 4시에 알림을 받도록 오후 6시에 설정하면 오후 4시의 알림을 아직 안 받았다고 판단해 오후 6시에 알림을 보내버림.
  * 개선) 당일에 알림을 안 받은 상태에 오후 4시에 알림을 받도록 오후 6시에 설정하면 오후 4시의 알림은 이미 지나간 알림이라서 당일에 추가적인 알림을 보내지 않음.

#### 📸 ScreenShot
<!-- Optional -->

##### ✅ PR check list
```
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label, Reviewer를 설정해주세요.
- 관련된 Issue Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #
